### PR TITLE
Fixes to be able to run this with 2024 chrome

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -10,6 +10,13 @@ RUN wget -nc https://dl.google.com/linux/direct/google-chrome-stable_current_amd
 RUN apt-get -y update
 # Installing Google Chrome
 RUN apt-get -y install -f ./google-chrome-stable_current_amd64.deb
+# Download Chrome Driver for installed Google Chrome version
+RUN wget -N "https://storage.googleapis.com/chrome-for-testing-public/$(google-chrome --version | awk '{print $3}')/linux64/chromedriver-linux64.zip" && \
+    unzip chromedriver-linux64.zip -d /usr/local/bin/ && \
+    rm chromedriver-linux64.zip && \
+    mv /usr/local/bin/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver && \
+    rm -r /usr/local/bin/chromedriver-linux64 && \
+    chmod +x /usr/local/bin/chromedriver
 
 # Exposing our app port in docker internal network
 EXPOSE 80

--- a/app/api/getInseratDetails.py
+++ b/app/api/getInseratDetails.py
@@ -17,10 +17,11 @@ from functions.getProxy import *
 from functions.getUserAgent import *
 
 def getInseratDetails(url):
-    
+    chrome_driver_path = "/usr/local/bin/chromedriver"
+    driver = None
     try:
         start_time = time.time()
- 
+
         proxy = getProxy()
 
         prox_options = {
@@ -35,7 +36,7 @@ def getInseratDetails(url):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--user-agent='+GET_UA())
         options.add_argument('--incognito')
-        driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options, seleniumwire_options=prox_options)
+        driver = webdriver.Chrome(service=Service(chrome_driver_path), options=options, seleniumwire_options=prox_options)
 
         driver.get(url)
 
@@ -78,7 +79,6 @@ def getInseratDetails(url):
             return(imgSrcArr)
 
         imgSrcArr1 = getImages(url)
-        
 
         tagsSrcDivs = driver.find_elements(By.CLASS_NAME, 'breadcrump-link')
         tagsSrcArr = []
@@ -104,7 +104,7 @@ def getInseratDetails(url):
             adId = "0"
 
         data = {'title':title, 'price': price, 'images':imgSrcArr1, 'tags':tagsSrcArr, 'views':views, 'description':description, 'uploadDate':uploadDate, 'adId':adId}
-        
+
         end_time = time.time()
 
         print("getInseratDetails.py execution:")

--- a/app/api/getViews.py
+++ b/app/api/getViews.py
@@ -17,9 +17,11 @@ from functions.getProxy import *
 from functions.getUserAgent import *
 
 def getViews(url):
+    chrome_driver_path = "/usr/local/bin/chromedriver"
+    driver = None
     try:
         start_time = time.time()
-              
+
         proxy = getProxy()
 
         prox_options = {
@@ -34,7 +36,7 @@ def getViews(url):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--user-agent='+GET_UA())
         options.add_argument('--incognito')
-        driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options, seleniumwire_options=prox_options)
+        driver = webdriver.Chrome(service=Service(chrome_driver_path), options=options, seleniumwire_options=prox_options)
 
         driver.get(url)
 

--- a/app/api/scrapeInserate.py
+++ b/app/api/scrapeInserate.py
@@ -16,9 +16,9 @@ import time
 from functions.getProxy import *
 from functions.getUserAgent import *
 
-
 def scrapeInserateUrls():
-
+    chrome_driver_path = '/usr/local/bin/chromedriver'
+    driver = None
     try:
         start_time = time.time()
 
@@ -38,7 +38,7 @@ def scrapeInserateUrls():
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--user-agent='+GET_UA())
         options.add_argument('--incognito')
-        driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options, seleniumwire_options=prox_options)
+        driver = webdriver.Chrome(service=Service(chrome_driver_path), options=options, seleniumwire_options=prox_options)
 
         driver.get(url)
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,8 +1,10 @@
 beautifulsoup4==4.11.1
 Flask==2.2.2
+Werkzeug==2.2.2
 lxml==4.9.2
 requests==2.28.1
 selenium==4.7.2
 selenium_wire==5.1.0
 waitress==2.1.2
 webdriver_manager==3.8.5
+blinker==1.4

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -5,27 +5,26 @@ events {}
 http {
     upstream app {
         server app;
-        server ebay-kleinanzeigen-api_app_1:80;
-        server ebay-kleinanzeigen-api_app_2:80;
-        server ebay-kleinanzeigen-api_app_3:80;
-        server ebay-kleinanzeigen-api_app_4:80;
-        server ebay-kleinanzeigen-api_app_5:80;
-        server ebay-kleinanzeigen-api_app_6:80;
-        server ebay-kleinanzeigen-api_app_7:80;
-        server ebay-kleinanzeigen-api_app_8:80;
-        server ebay-kleinanzeigen-api_app_9:80;
-        server ebay-kleinanzeigen-api_app_10:80;
-        server ebay-kleinanzeigen-api_app_11:80;
-        server ebay-kleinanzeigen-api_app_12:80;
-        server ebay-kleinanzeigen-api_app_13:80;
-        server ebay-kleinanzeigen-api_app_14:80;
-        server ebay-kleinanzeigen-api_app_15:80;
-        server ebay-kleinanzeigen-api_app_16:80;
-        server ebay-kleinanzeigen-api_app_17:80;
-        server ebay-kleinanzeigen-api_app_18:80;
-        server ebay-kleinanzeigen-api_app_19:80;
-        server ebay-kleinanzeigen-api_app_20:80;
-  
+        server ebay-kleinanzeigen-api-app-1:80;
+        server ebay-kleinanzeigen-api-app-2:80;
+        server ebay-kleinanzeigen-api-app-3:80; 
+        server ebay-kleinanzeigen-app-app-4:80;
+        server ebay-kleinanzeigen-app-app-5:80;
+        server ebay-kleinanzeigen-app-app-6:80;
+        server ebay-kleinanzeigen-app-app-7:80;
+        server ebay-kleinanzeigen-app-app-8:80;
+        server ebay-kleinanzeigen-app-app-9:80;
+        server ebay-kleinanzeigen-app-app-10:80;
+        server ebay-kleinanzeigen-app-app-11:80;
+        server ebay-kleinanzeigen-app-app-12:80;
+        server ebay-kleinanzeigen-app-app-13:80;
+        server ebay-kleinanzeigen-app-app-14:80;
+        server ebay-kleinanzeigen-app-app-15:80;
+        server ebay-kleinanzeigen-app-app-16:80;
+        server ebay-kleinanzeigen-app-app-17:80;
+        server ebay-kleinanzeigen-app-app-18:80;
+        server ebay-kleinanzeigen-app-app-19:80;
+        server ebay-kleinanzeigen-app-app-20:80; 
      }
 
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -8,23 +8,23 @@ http {
         server ebay-kleinanzeigen-api-app-1:80;
         server ebay-kleinanzeigen-api-app-2:80;
         server ebay-kleinanzeigen-api-app-3:80; 
-        server ebay-kleinanzeigen-app-app-4:80;
-        server ebay-kleinanzeigen-app-app-5:80;
-        server ebay-kleinanzeigen-app-app-6:80;
-        server ebay-kleinanzeigen-app-app-7:80;
-        server ebay-kleinanzeigen-app-app-8:80;
-        server ebay-kleinanzeigen-app-app-9:80;
-        server ebay-kleinanzeigen-app-app-10:80;
-        server ebay-kleinanzeigen-app-app-11:80;
-        server ebay-kleinanzeigen-app-app-12:80;
-        server ebay-kleinanzeigen-app-app-13:80;
-        server ebay-kleinanzeigen-app-app-14:80;
-        server ebay-kleinanzeigen-app-app-15:80;
-        server ebay-kleinanzeigen-app-app-16:80;
-        server ebay-kleinanzeigen-app-app-17:80;
-        server ebay-kleinanzeigen-app-app-18:80;
-        server ebay-kleinanzeigen-app-app-19:80;
-        server ebay-kleinanzeigen-app-app-20:80; 
+        server ebay-kleinanzeigen-api-app-4:80;
+        server ebay-kleinanzeigen-api-app-5:80;
+        server ebay-kleinanzeigen-api-app-6:80;
+        server ebay-kleinanzeigen-api-app-7:80;
+        server ebay-kleinanzeigen-api-app-8:80;
+        server ebay-kleinanzeigen-api-app-9:80;
+        server ebay-kleinanzeigen-api-app-10:80;
+        server ebay-kleinanzeigen-api-app-11:80;
+        server ebay-kleinanzeigen-api-app-12:80;
+        server ebay-kleinanzeigen-api-app-13:80;
+        server ebay-kleinanzeigen-api-app-14:80;
+        server ebay-kleinanzeigen-api-app-15:80;
+        server ebay-kleinanzeigen-api-app-16:80;
+        server ebay-kleinanzeigen-api-app-17:80;
+        server ebay-kleinanzeigen-api-app-18:80;
+        server ebay-kleinanzeigen-api-app-19:80;
+        server ebay-kleinanzeigen-api-app-20:80; 
      }
 
 


### PR DESCRIPTION
- added in dynamic chromedriver download for installed chrome version
- fixed container names in nginx config
- load chromedriver from static path
- added in missing requirements

dont know why its like that with the container names, need to check if its depending on the platform or if it was a change in the framework