### PR TITLE
Add listing status to inserat details API response

### DIFF
--- a/scrapers/inserat.py
+++ b/scrapers/inserat.py
@@ -21,8 +21,9 @@ async def get_inserate_details(url: str, page):
         status = "active"  # Default status
         title_element = await page.query_selector("#viewad-title")
         if title_element:
-            title_classes = await title_element.get_attribute("class")
-            if "data-soldlabel" in await title_element.evaluate("el => el.outerHTML"):
+            # Check for sold status by looking at the data-soldlabel attribute value
+            sold_label = await title_element.get_attribute("data-soldlabel")
+            if sold_label and sold_label.strip():
                 status = "sold"
             
             # Check for reserved or deleted status in the title text

--- a/scrapers/inserat.py
+++ b/scrapers/inserat.py
@@ -16,6 +16,22 @@ async def get_inserate_details(url: str, page):
                                               default="[ERROR] Ad ID not found")
         categories = [cat.strip() for cat in await lib.get_elements_content(page, ".breadcrump-link") if cat.strip()]
         title = await lib.get_element_content(page, "#viewad-title", default="[ERROR] Title not found")
+        
+        # Extract status from title element
+        status = "active"  # Default status
+        title_element = await page.query_selector("#viewad-title")
+        if title_element:
+            title_classes = await title_element.get_attribute("class")
+            if "data-soldlabel" in await title_element.evaluate("el => el.outerHTML"):
+                status = "sold"
+            
+            # Check for reserved or deleted status in the title text
+            title_text = await title_element.inner_text()
+            if "Reserviert •" in title_text:
+                status = "reserved"
+            elif "Gelöscht •" in title_text:
+                status = "deleted"
+        
         price_element = await lib.get_element_content(page, "#viewad-price")
         price = lib.parse_price(price_element)
         views = await lib.get_element_content(page, "#viewad-cntr-num")
@@ -36,6 +52,7 @@ async def get_inserate_details(url: str, page):
             "id": ad_id,
             "categories": categories,
             "title": title.split(" • ")[-1].strip() if " • " in title else title.strip(),
+            "status": status,
             "price": price,
             "shipping": True if shipping else False,
             "location": location,

--- a/scrapers/inserat.py
+++ b/scrapers/inserat.py
@@ -21,17 +21,25 @@ async def get_inserate_details(url: str, page):
         status = "active"  # Default status
         title_element = await page.query_selector("#viewad-title")
         if title_element:
-            # Check for sold status by looking at the data-soldlabel attribute value
-            sold_label = await title_element.get_attribute("data-soldlabel")
-            if sold_label and sold_label.strip():
-                status = "sold"
-            
-            # Check for reserved or deleted status in the title text
             title_text = await title_element.inner_text()
-            if "Reserviert •" in title_text:
+            
+            # Check for specific status indicators in the title text
+            if "Verkauft" in title_text:
+                status = "sold"
+            elif "Reserviert •" in title_text:
                 status = "reserved"
             elif "Gelöscht •" in title_text:
                 status = "deleted"
+            
+            # Additional check for sold class
+            title_classes = await title_element.get_attribute("class")
+            if title_classes and "is-sold" in title_classes:
+                status = "sold"
+        
+        # Final check for sold status in the page content
+        sold_badge = await page.query_selector(".badge-sold")
+        if sold_badge:
+            status = "sold"
         
         price_element = await lib.get_element_content(page, "#viewad-price")
         price = lib.parse_price(price_element)


### PR DESCRIPTION
## Description
As a user of the Ebay Kleinanzeigen API, I want to know the status of a listing (active, sold, reserved, or deleted) so that I can filter and process listings based on their availability status.

## Acceptance Criteria
- The API should extract the status from the listing page
- The status should be included in the API response as a new field called "status"
- The status should be one of the following values:
  - "active" (default)
  - "sold" (when the listing has the sold label)
  - "reserved" (when the listing title contains "Reserviert •")
  - "deleted" (when the listing title contains "Gelöscht •")
- The status extraction should not break existing functionality

## Technical Details
The status can be extracted from the title element (#viewad-title) by:
1. Checking for the data-soldlabel attribute to identify sold items
2. Checking the inner text for "Reserviert •" or "Gelöscht •" prefixes

## Implementation Notes
- The status field should be added to the returned JSON object in the inserat details endpoint
- Default status should be "active" if no other status is detected

## Testing
Scraped HTML - Element
<img width="714" alt="Bildschirmfoto 2025-03-16 um 14 26 16" src="https://github.com/user-attachments/assets/5f62997f-0788-4f52-a7ac-8107d91d1d4c" />
Inserat with status: "reserved"
<img width="1097" alt="Bildschirmfoto 2025-03-16 um 14 22 39" src="https://github.com/user-attachments/assets/9d4bd0ed-98a1-4740-958d-e09c402382c5" />
API Response GET /inserat
<img width="775" alt="Bildschirmfoto 2025-03-16 um 14 24 34" src="https://github.com/user-attachments/assets/8ca71abd-4821-4322-9d7c-6e88fcf73737" />
Inserat with status: "deleted"
<img width="1055" alt="Bildschirmfoto 2025-03-16 um 14 25 08" src="https://github.com/user-attachments/assets/9822c9d5-3eab-421d-9aa8-4a0694a4e6fe" />
API Response GET /inserat
<img width="775" alt="Bildschirmfoto 2025-03-16 um 14 24 18" src="https://github.com/user-attachments/assets/ee451596-e815-4b9c-94db-37f32435eabb" />


