### PR TITLE
Add URL-passthrough scraping, publish date, and rate-limit fixes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -207,7 +207,8 @@ curl -X POST http://localhost:8000/inserate-by-url \
       "url": "https://www.kleinanzeigen.de/s-anzeige/...",
       "title": "VW Golf Variant 2.0 TDI Automatik Klima",
       "price": "12500",
-      "description": "Gepflegter Zustand, Erstbesitz..."
+      "description": "Gepflegter Zustand, Erstbesitz...",
+      "published_at": "2026-05-03T22:06:00"
     }
   ],
   "unique_results": 75,
@@ -236,6 +237,7 @@ curl -X POST http://localhost:8000/inserate-by-url \
   - `title` — Listing title
   - `price` — Price as string (numeric digits only, no currency symbol; empty string if not set)
   - `description` — Short teaser text from the listing card
+  - `published_at` — ISO 8601 publish datetime (e.g. `"2026-05-03T22:06:00"`). Older listings show only the date at midnight (`"2026-04-26T00:00:00"`). `null` if not shown on the card.
 - **`unique_results`**: Total number of listings returned across all fetched pages.
 - **`total_results`**: Total hits reported by Kleinanzeigen for this search (e.g. `120140`). Extracted from the page breadcrumb on the first page load — no extra request needed.
 - **`time_taken`**: Total elapsed time in seconds.
@@ -325,7 +327,8 @@ The `/inserate-detailed` response additionally nests a `details` object inside e
       "url": "https://www.kleinanzeigen.de/s-anzeige/...",
       "title": "Example Item",
       "price": "100",
-      "description": "Short teaser text..."
+      "description": "Short teaser text...",
+      "published_at": "2026-05-03T22:06:00"
     }
   ],
   "unique_results": 75,

--- a/README.MD
+++ b/README.MD
@@ -124,11 +124,17 @@ The API will be available at `http://localhost:8000`
 - **`min_price`** *(integer, optional)*: The minimum price in Euros for the listings (e.g., `200` for at least 200 Euros).
 - **`max_price`** *(integer, optional)*: The maximum price in Euros for the listings (e.g., `500` for at most 500 Euros).
 - **`page_count`** *(integer, optional)*: The number of pages to search or return (e.g., `5` for the first 5 pages, default is 1, max: 20 pages).
+- **`min_publish_date`** *(datetime, optional)*: Stop fetching once a page contains listings published before this datetime. Listings older than the threshold are removed from the final results. Format: `YYYY-MM-DDTHH:MM:SS` (e.g., `2026-05-03T08:00:00`). Useful for intraday runs that should only collect new listings.
 
-##### Example Request
+##### Example Requests
 
 ```http
 GET /inserate?query=fahrrad&location=10178&radius=5&min_price=200&page_count=5
+```
+
+**With `min_publish_date` — stop when listings older than this morning are reached:**
+```sh
+curl "http://localhost:8000/inserate?query=fahrrad&page_count=10&min_publish_date=2026-05-04T08:00:00"
 ```
 
 #### 2. Fetch Listing Details
@@ -184,6 +190,7 @@ Pages are fetched **sequentially** to avoid IP-level rate limiting by Kleinanzei
 
 - **`url`** *(string, required)*: Any Kleinanzeigen search or category URL.
 - **`max_pages`** *(integer, optional)*: Number of pages to fetch (default: 1). Each page returns up to 25 listings.
+- **`min_publish_date`** *(datetime, optional)*: Stop fetching once a page contains listings published before this datetime. Listings older than the threshold are removed from the final results. Format: `YYYY-MM-DDTHH:MM:SS`. Supports intraday precision — e.g. `"2026-05-04T08:00:00"` keeps only listings from that morning onward.
 
 ##### curl Examples
 
@@ -226,6 +233,54 @@ curl -X POST http://localhost:8000/inserate-by-url \
     "max_pages": 2
   }'
 ```
+
+**With `min_publish_date` — stop once listings older than this morning are found (intraday run):**
+```sh
+curl -s -X POST http://localhost:8000/inserate-by-url \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen",
+    "max_pages": 20,
+    "min_publish_date": "2026-05-04T08:00:00"
+  }' | python -m json.tool
+```
+Expected: `pages_requested` < 20, all `published_at` values ≥ `"2026-05-04T08:00:00"`.
+
+**Verify early-stop: future cutoff → 0 results, only 1 page fetched:**
+```sh
+curl -s -X POST http://localhost:8000/inserate-by-url \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen",
+    "max_pages": 5,
+    "min_publish_date": "2099-01-01T00:00:00"
+  }' | python -m json.tool
+```
+Expected: `"unique_results": 0`, `"pages_requested": 1`.
+
+**Verify no false filtering: past cutoff → full 25 results:**
+```sh
+curl -s -X POST http://localhost:8000/inserate-by-url \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen",
+    "max_pages": 1,
+    "min_publish_date": "2000-01-01T00:00:00"
+  }' | python -m json.tool
+```
+Expected: `"unique_results": 25`.
+
+**Verify schema enforcement: plain date string → HTTP 422:**
+```sh
+curl -s -X POST http://localhost:8000/inserate-by-url \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen",
+    "max_pages": 1,
+    "min_publish_date": "2026-05-04"
+  }' | python -m json.tool
+```
+Expected: HTTP 422 — the time component is required.
 
 **Pretty-print the response with Python:**
 ```sh
@@ -469,6 +524,25 @@ Distributed under the MIT License. See `LICENSE` for more information.
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ## Changelog
+
+### May 2026 — Intraday `min_publish_date` precision (datetime)
+
+**Maintainer:** [Darko Palić](https://github.com/dpalic)
+
+#### Changed
+
+- **`min_publish_date` upgraded from `date` to `datetime`** on both `GET /inserate` and `POST /inserate-by-url`. The parameter now accepts a full ISO 8601 datetime string (`YYYY-MM-DDTHH:MM:SS`) instead of a plain date. This enables intraday filtering — e.g. `"2026-05-04T08:00:00"` keeps only listings published from that exact time onward, not just from that calendar day.
+- The internal comparison in `_page_has_old_listings` and `_filter_by_min_publish_date` now operates on full `datetime` objects instead of stripping to `.date()`, preserving hour/minute precision.
+- German date strings (`"Heute, 08:46"`, `"Gestern, 14:29"`) already produced full ISO 8601 datetimes — no parsing changes required.
+
+#### Tests
+
+- 3 new live integration tests in `tests/test_inserate_by_url_live.py` covering `min_publish_date`:
+  - Future cutoff (`2099-01-01T00:00:00`) returns 0 results and stops after page 1.
+  - Past cutoff (`2000-01-01T00:00:00`) does not filter anything — result count unchanged.
+  - All returned `published_at` values satisfy the cutoff when a real intraday threshold is used.
+
+---
 
 ### May 2026 — URL-passthrough scraping, publish date, rate-limit fixes
 

--- a/README.MD
+++ b/README.MD
@@ -60,6 +60,14 @@ uvicorn main:app --reload
 
 The API will be available at `http://localhost:8000`
 
+#### Non-headless mode (visible browser)
+
+Set the `HEADLESS` environment variable to `false` to watch the browser while scraping — useful during development:
+
+```sh
+HEADLESS=false uvicorn main:app --reload
+```
+
 ### Installation using UV
 
 #### Prerequisites
@@ -76,6 +84,12 @@ uv sync
 
 ```sh
 uv run uvicorn main:app --reload
+```
+
+#### Non-headless mode with UV
+
+```sh
+HEADLESS=false uv run uvicorn main:app --reload
 ```
 
 ### Installation using Docker
@@ -151,53 +165,199 @@ Same as `/inserate` endpoint, plus:
 GET /inserate-detailed?query=laptop&page_count=2&max_concurrent_details=5
 ```
 
+#### 4. Scrape by URL
+
+**Endpoint:** `POST /inserate-by-url`
+
+**Description:** Scrape listings using a full Kleinanzeigen search URL. All filters already encoded in the URL (category, brand, year, fuel type, transmission, car type, etc.) are preserved as-is. Page numbers are injected automatically for multi-page fetching. Use this when `/inserate` does not yet support a filter you need.
+
+Pages are fetched **sequentially** to avoid IP-level rate limiting by Kleinanzeigen.
+
+##### Request Body
+
+```json
+{
+  "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen",
+  "max_pages": 3
+}
+```
+
+- **`url`** *(string, required)*: Any Kleinanzeigen search or category URL.
+- **`max_pages`** *(integer, optional)*: Number of pages to fetch (default: 1). Each page returns up to 25 listings.
+
+##### Example Request
+
+```sh
+curl -X POST http://localhost:8000/inserate-by-url \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.ez_i:2008%2C+autos.fuel_s:(cng%2Clpg)+autos.marke_s:volkswagen+autos.shift_s:automatik+autos.typ_s:(kombi%2Csuv)",
+    "max_pages": 3
+  }'
+```
+
+##### Example Response
+
+```json
+{
+  "success": true,
+  "results": [
+    {
+      "adid": "3398033022",
+      "url": "https://www.kleinanzeigen.de/s-anzeige/...",
+      "title": "VW Golf Variant 2.0 TDI Automatik Klima",
+      "price": "12500",
+      "description": "Gepflegter Zustand, Erstbesitz..."
+    }
+  ],
+  "unique_results": 75,
+  "total_results": 120140,
+  "time_taken": 12.358,
+  "performance_metrics": {
+    "pages_requested": 3,
+    "pages_successful": 3,
+    "success_rate": 100.0,
+    "average_page_time": 4.119
+  },
+  "browser_metrics": {
+    "contexts_created": 3,
+    "contexts_reused": 0,
+    "contexts_in_pool": 3,
+    "contexts_in_use": 0
+  }
+}
+```
+
+**Response fields:**
+
+- **`results`**: Array of listing objects. Each listing contains:
+  - `adid` — Kleinanzeigen internal listing ID
+  - `url` — Direct link to the listing
+  - `title` — Listing title
+  - `price` — Price as string (numeric digits only, no currency symbol; empty string if not set)
+  - `description` — Short teaser text from the listing card
+- **`unique_results`**: Total number of listings returned across all fetched pages.
+- **`total_results`**: Total hits reported by Kleinanzeigen for this search (e.g. `120140`). Extracted from the page breadcrumb on the first page load — no extra request needed.
+- **`time_taken`**: Total elapsed time in seconds.
+- **`performance_metrics.pages_requested`** / **`pages_successful`** / **`success_rate`**: Page-level fetch statistics.
+
+#### 5. Convert URL to API Parameters
+
+**Endpoint:** `POST /convert-url`
+
+**Description:** Parses a Kleinanzeigen URL and returns two groups of parameters: `inserate_params` (what the `/inserate` endpoint currently understands) and `unmapped` (filters not yet supported by `/inserate`, such as category, brand, year, or transmission). Useful for inspecting which parts of a URL can be expressed via the structured API.
+
+##### Request Body
+
+```json
+{
+  "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen"
+}
+```
+
+##### Example Request
+
+```sh
+curl -X POST http://localhost:8000/convert-url \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.ez_i:2008%2C+autos.marke_s:volkswagen"}' \
+  | python -m json.tool
+```
+
+##### Example Response
+
+```json
+{
+  "inserate_params": {
+    "query": "klima",
+    "page_count": 1
+  },
+  "unmapped": {
+    "category_slug": "s-autos",
+    "subcategory": "volkswagen",
+    "category_id": 216,
+    "year_from": 2008,
+    "year_to": null,
+    "brands": ["volkswagen"]
+  }
+}
+```
+
 ### Documentation
 
 #### API Response Format
 
-All API endpoints return responses in the following JSON format:
-
-##### API Response Format
+##### `GET /inserate` and `GET /inserate-detailed`
 
 ```json
 {
   "success": true,
   "time_taken": 1.23,
-  "unique_results": 100,
-  "data": [...],
-  "performance_metrics": {
-    "pages_requested": 5,
-    "pages_successful": 5,
-    "success_rate": 100.0,
-    "average_page_time": 2.45
-  }
-}
-```
-
-##### Combined Endpoint Response Format
-
-```json
-{
-  "success": true,
-  "time_taken": 3.45,
   "unique_results": 25,
   "data": [
     {
       "adid": "123456",
+      "url": "https://www.kleinanzeigen.de/s-anzeige/...",
       "title": "Example Item",
       "price": "100",
-      "details": {
-        "id": "123456",
-        "description": "Full description...",
-        "seller": {...},
-        "location": {...}
-      }
+      "description": "Short teaser text..."
     }
   ],
   "performance_metrics": {
-    "listings_found": 25,
-    "details_fetched": 25,
-    "success_rate": 100.0
+    "pages_requested": 1,
+    "pages_successful": 1,
+    "success_rate": 100.0,
+    "average_page_time": 1.23
+  }
+}
+```
+
+The `/inserate-detailed` response additionally nests a `details` object inside each listing with full description, seller info, and location.
+
+##### `POST /inserate-by-url`
+
+```json
+{
+  "success": true,
+  "results": [
+    {
+      "adid": "123456",
+      "url": "https://www.kleinanzeigen.de/s-anzeige/...",
+      "title": "Example Item",
+      "price": "100",
+      "description": "Short teaser text..."
+    }
+  ],
+  "unique_results": 75,
+  "total_results": 120140,
+  "time_taken": 12.358,
+  "performance_metrics": {
+    "pages_requested": 3,
+    "pages_successful": 3,
+    "success_rate": 100.0,
+    "average_page_time": 4.119
+  },
+  "browser_metrics": { ... }
+}
+```
+
+`total_results` is the total hit count shown by Kleinanzeigen (e.g. `120140`). It is extracted from the breadcrumb of the first page — no extra request is made. The field is omitted if the breadcrumb is not found.
+
+##### `POST /convert-url`
+
+```json
+{
+  "inserate_params": {
+    "query": "klima",
+    "page_count": 1
+  },
+  "unmapped": {
+    "category_slug": "s-autos",
+    "subcategory": "volkswagen",
+    "category_id": 216,
+    "year_from": 2008,
+    "year_to": null,
+    "brands": ["volkswagen"]
   }
 }
 ```

--- a/README.MD
+++ b/README.MD
@@ -185,8 +185,29 @@ Pages are fetched **sequentially** to avoid IP-level rate limiting by Kleinanzei
 - **`url`** *(string, required)*: Any Kleinanzeigen search or category URL.
 - **`max_pages`** *(integer, optional)*: Number of pages to fetch (default: 1). Each page returns up to 25 listings.
 
-##### Example Request
+##### curl Examples
 
+**Single page — VW with Klima (25 results):**
+```sh
+curl -X POST http://localhost:8000/inserate-by-url \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen",
+    "max_pages": 1
+  }'
+```
+
+**3 pages — VW with Klima (up to 75 results):**
+```sh
+curl -X POST http://localhost:8000/inserate-by-url \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen",
+    "max_pages": 3
+  }'
+```
+
+**With full filters — VW Kombi/SUV, Automatik, CNG/LPG, ab 2008, 3 pages:**
 ```sh
 curl -X POST http://localhost:8000/inserate-by-url \
   -H "Content-Type: application/json" \
@@ -194,6 +215,24 @@ curl -X POST http://localhost:8000/inserate-by-url \
     "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.ez_i:2008%2C+autos.fuel_s:(cng%2Clpg)+autos.marke_s:volkswagen+autos.shift_s:automatik+autos.typ_s:(kombi%2Csuv)",
     "max_pages": 3
   }'
+```
+
+**Wohnwagen — Fendt, Klima, max 15.000 €, ab 2008:**
+```sh
+curl -X POST http://localhost:8000/inserate-by-url \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://www.kleinanzeigen.de/s-wohnwagen-mobile/wohnwagen/preis::15000/klima/k0c220+wohnwagen_mobile.art_s:wohnwagen+wohnwagen_mobile.ez_i:2008%2C+wohnwagen_mobile.marke_s:fendt",
+    "max_pages": 2
+  }'
+```
+
+**Pretty-print the response with Python:**
+```sh
+curl -s -X POST http://localhost:8000/inserate-by-url \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen", "max_pages": 1}' \
+  | python -m json.tool
 ```
 
 ##### Example Response
@@ -257,12 +296,29 @@ curl -X POST http://localhost:8000/inserate-by-url \
 }
 ```
 
-##### Example Request
+##### curl Examples
 
+**Basic — category + keyword only:**
+```sh
+curl -X POST http://localhost:8000/convert-url \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen"}' \
+  | python -m json.tool
+```
+
+**With year filter:**
 ```sh
 curl -X POST http://localhost:8000/convert-url \
   -H "Content-Type: application/json" \
   -d '{"url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.ez_i:2008%2C+autos.marke_s:volkswagen"}' \
+  | python -m json.tool
+```
+
+**With full filters — fuel, transmission, body type:**
+```sh
+curl -X POST http://localhost:8000/convert-url \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.ez_i:2008%2C+autos.fuel_s:(cng%2Clpg)+autos.marke_s:volkswagen+autos.shift_s:automatik+autos.typ_s:(kombi%2Csuv)"}' \
   | python -m json.tool
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -467,3 +467,28 @@ API documentation is available at `http://localhost:8000/docs` when running loca
 Distributed under the MIT License. See `LICENSE` for more information.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Changelog
+
+### May 2026 — URL-passthrough scraping, publish date, rate-limit fixes
+
+**Maintainer:** [Darko Palić](https://github.com/dpalic)
+
+#### New endpoints
+
+- **`POST /inserate-by-url`** — scrape listings using any full Kleinanzeigen search URL. All filters encoded in the URL (category, brand, year, fuel type, transmission, body type, etc.) are preserved as-is. Page numbers are injected automatically for multi-page fetching. Response includes `total_results` (total hit count from the page breadcrumb, no extra request) and `published_at` on every listing.
+- **`POST /convert-url`** — parse a Kleinanzeigen URL into `inserate_params` (what `/inserate` understands today) and `unmapped` (filters not yet supported by the structured endpoint).
+
+#### New listing field
+
+- **`published_at`** — ISO 8601 publish datetime added to every listing result (e.g. `"2026-05-04T22:06:00"`). Extracted from the listing card during the existing page load — no extra request. Older listings return a date-only value (`"2026-04-26T00:00:00"`); `null` if not shown on the card.
+
+#### Bug fixes
+
+- **Cookie clearing on context release** — browser contexts now have session cookies cleared before returning to the pool, preventing Kleinanzeigen tracking state from carrying over between unrelated requests and causing silent empty results on pages 2+.
+- **Inter-page delay** — a 2-second pause between sequential page fetches within a single multi-page scrape reduces bot-detection false positives.
+
+#### Tests
+
+- 11 unit tests for `/convert-url` (`tests/test_convert_url.py`, no server required)
+- 14 live integration tests for `/inserate-by-url` (`tests/test_inserate_by_url_live.py`), covering JSON structure, `published_at`, `total_results`, and exact result counts for 1–4 pages (25 / 50 / 75 / 100 results)

--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@ from routers import (
     inserate_ultra as inserate,
     inserat,
     inserate_detailed_ultra as inserate_detailed,
+    convert_url,
+    inserate_by_url,
 )
 from utils.browser import OptimizedPlaywrightManager
 from utils.asyncio_optimizations import EventLoopOptimizer
@@ -53,3 +55,5 @@ async def root():
 app.include_router(inserate.router)
 app.include_router(inserat.router)
 app.include_router(inserate_detailed.router)
+app.include_router(convert_url.router)
+app.include_router(inserate_by_url.router)

--- a/routers/convert_url.py
+++ b/routers/convert_url.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from utils.parse_kleinanzeigen_url import parse_kleinanzeigen_url, map_to_inserate_params
+
+router = APIRouter()
+
+
+class ConvertUrlRequest(BaseModel):
+    url: str
+
+
+@router.post("/convert-url")
+async def convert_url(request: ConvertUrlRequest):
+    parsed = parse_kleinanzeigen_url(request.url)
+    inserate_params, unmapped = map_to_inserate_params(parsed)
+    return {"inserate_params": inserate_params, "unmapped": unmapped}

--- a/routers/inserate_by_url.py
+++ b/routers/inserate_by_url.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from typing import Optional
+
 from fastapi import APIRouter, Request, HTTPException
 from pydantic import BaseModel
 
@@ -7,6 +10,7 @@ router = APIRouter()
 class InserateByUrlRequest(BaseModel):
     url: str
     max_pages: int = 1
+    min_publish_date: Optional[datetime] = None
 
 
 @router.post("/inserate-by-url")
@@ -29,6 +33,7 @@ async def inserate_by_url(request: Request, body: InserateByUrlRequest):
             browser_manager=browser_manager,
             base_url=body.url,
             max_pages=body.max_pages,
+            min_publish_date=body.min_publish_date,
         )
     except HTTPException:
         raise

--- a/routers/inserate_by_url.py
+++ b/routers/inserate_by_url.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Request, HTTPException
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class InserateByUrlRequest(BaseModel):
+    url: str
+    max_pages: int = 1
+
+
+@router.post("/inserate-by-url")
+async def inserate_by_url(request: Request, body: InserateByUrlRequest):
+    """
+    Scrape Kleinanzeigen listings using a full URL with all filters pre-configured.
+
+    Pass any Kleinanzeigen search/category URL — all filters encoded in the URL
+    (category, brand, year, fuel type, transmission, etc.) are preserved as-is.
+    Page numbers are injected automatically for multi-page fetching.
+    """
+    browser_manager = request.app.state.browser_manager
+    if not browser_manager:
+        raise HTTPException(status_code=503, detail="Service unavailable")
+
+    from scrapers.inserate_by_url import scrape_by_url
+
+    try:
+        return await scrape_by_url(
+            browser_manager=browser_manager,
+            base_url=body.url,
+            max_pages=body.max_pages,
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/routers/inserate_ultra.py
+++ b/routers/inserate_ultra.py
@@ -2,6 +2,9 @@
 Ultra-optimized router for maximum performance scraping.
 """
 
+from datetime import datetime
+from typing import Optional
+
 from fastapi import APIRouter, Query, Request, HTTPException
 from scrapers.inserate_ultra_optimized import ultra_optimized_scrape_inserate
 
@@ -17,6 +20,7 @@ async def get_inserate_ultra_optimized(
     min_price: int = Query(None, description="Minimum price filter"),
     max_price: int = Query(None, description="Maximum price filter"),
     page_count: int = Query(1, ge=1, le=20, description="Number of pages to fetch"),
+    min_publish_date: Optional[datetime] = Query(None, description="Stop fetching once listings published before this datetime (inclusive, format: YYYY-MM-DDTHH:MM:SS)"),
 ):
     """
     Fetch listings based on search criteria.
@@ -39,6 +43,7 @@ async def get_inserate_ultra_optimized(
             min_price=min_price,
             max_price=max_price,
             page_count=page_count,
+            min_publish_date=min_publish_date,
         )
 
         # Clean up response - remove excessive metrics for production

--- a/scrapers/inserate_by_url.py
+++ b/scrapers/inserate_by_url.py
@@ -71,7 +71,10 @@ async def scrape_by_url(
 
         # Fetch pages sequentially — Kleinanzeigen blocks concurrent requests
         # from the same IP even with staggered starts.
+        # A short delay between pages further reduces bot-detection risk.
         for page_num in range(1, max_pages + 1):
+            if page_num > 1:
+                await asyncio.sleep(2)
             result = await scraper.ultra_optimized_fetch_page(
                 inject_page(base_url, page_num), page_num,
                 extra_selectors=_TOTAL_RESULTS_SELECTOR if page_num == 1 else None,

--- a/scrapers/inserate_by_url.py
+++ b/scrapers/inserate_by_url.py
@@ -1,0 +1,118 @@
+"""
+URL-passthrough scraper: takes a full Kleinanzeigen URL and injects page numbers.
+Reuses UltraOptimizedScraper for fetching/extraction; only the URL-building differs.
+"""
+
+import asyncio
+import gc
+import re
+from typing import Dict, Any, Optional
+
+from utils.browser import OptimizedPlaywrightManager
+from utils.performance import PerformanceTracker
+from scrapers.inserate_ultra_optimized import create_ultra_optimized_scraper
+
+_TOTAL_RESULTS_SELECTOR = {"breadcrump_summary": ".breadcrump-summary"}
+
+
+def inject_page(url: str, page_num: int) -> str:
+    """
+    Strip any existing seite/s-seite segment and inject the requested page number.
+
+    Category URLs: seite:N is inserted at position 2 (after slug and subcategory),
+    matching Kleinanzeigen's own pagination format:
+      /s-autos/volkswagen/seite:2/klima/k0c216+...
+    Generic search URLs (no filter segment): s-seite:N before the query string.
+    """
+    from urllib.parse import urlparse, urlunparse, unquote
+
+    parsed = urlparse(url)
+    path = unquote(parsed.path)
+
+    # Strip any existing page segment
+    segments = [s for s in path.strip("/").split("/")
+                if s and not re.match(r"^s-seite:\d+$", s) and not re.match(r"^seite:\d+$", s)]
+
+    if page_num > 1:
+        has_filter = any(re.match(r"^k?\d*c\d+", s) for s in segments)
+        if has_filter:
+            # Insert seite:N at position 2 — Kleinanzeigen places it after subcategory
+            segments.insert(min(2, len(segments)), f"seite:{page_num}")
+        else:
+            # Generic search: append s-seite:N before query string
+            segments.append(f"s-seite:{page_num}")
+
+    new_path = "/" + "/".join(segments)
+    return urlunparse(parsed._replace(path=new_path))
+
+
+def _parse_total_results(breadcrump_text: str) -> Optional[int]:
+    match = re.search(r"von ([\d.]+)", breadcrump_text)
+    if match:
+        return int(match.group(1).replace(".", ""))
+    return None
+
+
+async def scrape_by_url(
+    browser_manager: OptimizedPlaywrightManager,
+    base_url: str,
+    max_pages: int = 1,
+) -> Dict[str, Any]:
+    """Scrape up to max_pages pages starting from base_url."""
+    scraper = await create_ultra_optimized_scraper(browser_manager)
+    tracker = PerformanceTracker()
+    tracker.start_request()
+
+    try:
+        batch_size = min(8, max_pages)
+        all_results = []
+        all_metrics = []
+        total_results: Optional[int] = None
+
+        # Fetch pages sequentially — Kleinanzeigen blocks concurrent requests
+        # from the same IP even with staggered starts.
+        for page_num in range(1, max_pages + 1):
+            result = await scraper.ultra_optimized_fetch_page(
+                inject_page(base_url, page_num), page_num,
+                extra_selectors=_TOTAL_RESULTS_SELECTOR if page_num == 1 else None,
+            )
+            if not isinstance(result, Exception):
+                page_results, page_metrics, extras = result
+                if total_results is None and "breadcrump_summary" in extras:
+                    total_results = _parse_total_results(extras["breadcrump_summary"])
+                all_results.extend(page_results)
+                all_metrics.append(page_metrics)
+                tracker.add_page_metric(page_metrics)
+            gc.collect()
+
+        tracker.set_concurrent_level(batch_size)
+        browser_metrics = browser_manager.get_performance_metrics()
+        tracker.set_browser_contexts_used(
+            browser_metrics["contexts_in_use"] + browser_metrics["contexts_in_pool"]
+        )
+        request_metrics = tracker.get_request_metrics()
+        request_metrics_dict = request_metrics.to_dict()
+
+        successful_pages = sum(1 for m in all_metrics if m.success)
+        success_rate = (successful_pages / max_pages) * 100 if max_pages > 0 else 0
+
+        response = {
+            "success": True,
+            "results": all_results,
+            "unique_results": len(all_results),
+            "time_taken": round(request_metrics.total_time, 3),
+            "performance_metrics": {
+                "pages_requested": max_pages,
+                "pages_successful": successful_pages,
+                "success_rate": round(success_rate, 2),
+                "average_page_time": round(request_metrics_dict.get("average_page_time", 0), 3),
+            },
+            "browser_metrics": browser_metrics,
+        }
+
+        if total_results is not None:
+            response["total_results"] = total_results
+
+        return response
+    finally:
+        await scraper.cleanup()

--- a/scrapers/inserate_by_url.py
+++ b/scrapers/inserate_by_url.py
@@ -6,11 +6,16 @@ Reuses UltraOptimizedScraper for fetching/extraction; only the URL-building diff
 import asyncio
 import gc
 import re
+from datetime import datetime
 from typing import Dict, Any, Optional
 
 from utils.browser import OptimizedPlaywrightManager
 from utils.performance import PerformanceTracker
-from scrapers.inserate_ultra_optimized import create_ultra_optimized_scraper
+from scrapers.inserate_ultra_optimized import (
+    create_ultra_optimized_scraper,
+    _page_has_old_listings,
+    _filter_by_min_publish_date,
+)
 
 _TOTAL_RESULTS_SELECTOR = {"breadcrump_summary": ".breadcrump-summary"}
 
@@ -57,8 +62,13 @@ async def scrape_by_url(
     browser_manager: OptimizedPlaywrightManager,
     base_url: str,
     max_pages: int = 1,
+    min_publish_date: datetime = None,
 ) -> Dict[str, Any]:
-    """Scrape up to max_pages pages starting from base_url."""
+    """Scrape up to max_pages pages starting from base_url.
+
+    If min_publish_date is set, stops fetching once a page contains listings
+    older than that date and trims those listings from the final results.
+    """
     scraper = await create_ultra_optimized_scraper(browser_manager)
     tracker = PerformanceTracker()
     tracker.start_request()
@@ -83,11 +93,20 @@ async def scrape_by_url(
                 page_results, page_metrics, extras = result
                 if total_results is None and "breadcrump_summary" in extras:
                     total_results = _parse_total_results(extras["breadcrump_summary"])
+
+                stop = min_publish_date and _page_has_old_listings(page_results, min_publish_date)
+                if min_publish_date:
+                    page_results = _filter_by_min_publish_date(page_results, min_publish_date)
+
                 all_results.extend(page_results)
                 all_metrics.append(page_metrics)
                 tracker.add_page_metric(page_metrics)
+
+                if stop:
+                    break
             gc.collect()
 
+        pages_attempted = len(all_metrics)
         tracker.set_concurrent_level(batch_size)
         browser_metrics = browser_manager.get_performance_metrics()
         tracker.set_browser_contexts_used(
@@ -97,7 +116,7 @@ async def scrape_by_url(
         request_metrics_dict = request_metrics.to_dict()
 
         successful_pages = sum(1 for m in all_metrics if m.success)
-        success_rate = (successful_pages / max_pages) * 100 if max_pages > 0 else 0
+        success_rate = (successful_pages / pages_attempted) * 100 if pages_attempted > 0 else 0
 
         response = {
             "success": True,
@@ -105,7 +124,7 @@ async def scrape_by_url(
             "unique_results": len(all_results),
             "time_taken": round(request_metrics.total_time, 3),
             "performance_metrics": {
-                "pages_requested": max_pages,
+                "pages_requested": pages_attempted,
                 "pages_successful": successful_pages,
                 "success_rate": round(success_rate, 2),
                 "average_page_time": round(request_metrics_dict.get("average_page_time", 0), 3),

--- a/scrapers/inserate_ultra_optimized.py
+++ b/scrapers/inserate_ultra_optimized.py
@@ -33,6 +33,25 @@ from utils.asyncio_optimizations import (
 )
 
 
+def _page_has_old_listings(results: list, min_publish_date: datetime) -> bool:
+    """Return True if any listing on this page was published before min_publish_date."""
+    for r in results:
+        pub = r.get("published_at")
+        if pub and datetime.fromisoformat(pub) < min_publish_date:
+            return True
+    return False
+
+
+def _filter_by_min_publish_date(results: list, min_publish_date: datetime) -> list:
+    """Remove listings published before min_publish_date. Null published_at entries are kept."""
+    out = []
+    for r in results:
+        pub = r.get("published_at")
+        if pub is None or datetime.fromisoformat(pub) >= min_publish_date:
+            out.append(r)
+    return out
+
+
 def _parse_kleinanzeigen_date(text: str) -> Optional[str]:
     """Convert a Kleinanzeigen listing date string to an ISO 8601 datetime string.
 
@@ -324,6 +343,7 @@ class UltraOptimizedScraper:
         min_price: int = None,
         max_price: int = None,
         page_count: int = 1,
+        min_publish_date: datetime = None,
     ) -> Dict[str, Any]:
         """
         Ultra-optimized multi-page scraping with all performance enhancements.
@@ -374,8 +394,12 @@ class UltraOptimizedScraper:
             batch_size = min(8, page_count)  # Optimal batch size based on testing
             all_results = []
             all_metrics = []
+            stop_early = False
 
             for i in range(0, len(page_numbers), batch_size):
+                if stop_early:
+                    break
+
                 batch_pages = page_numbers[i : i + batch_size]
 
                 # Create tasks for this batch
@@ -389,7 +413,6 @@ class UltraOptimizedScraper:
                 # Process batch results
                 for result in batch_results:
                     if isinstance(result, Exception):
-                        # Handle unexpected exceptions
                         logger.log_error(
                             ErrorClassifier.classify_exception(
                                 result,
@@ -400,6 +423,11 @@ class UltraOptimizedScraper:
                         continue
 
                     page_results, page_metrics, _ = result
+
+                    if min_publish_date and _page_has_old_listings(page_results, min_publish_date):
+                        page_results = _filter_by_min_publish_date(page_results, min_publish_date)
+                        stop_early = True
+
                     all_results.extend(page_results)
                     all_metrics.append(page_metrics)
                     tracker.add_page_metric(page_metrics)
@@ -418,10 +446,11 @@ class UltraOptimizedScraper:
             request_metrics = tracker.get_request_metrics()
             task_metrics = self.task_manager.get_metrics()
 
-            # Calculate success statistics
+            # Calculate success statistics against actual pages attempted
+            pages_attempted = len(all_metrics)
             successful_pages = sum(1 for m in all_metrics if m.success)
             success_rate = (
-                (successful_pages / page_count) * 100 if page_count > 0 else 0
+                (successful_pages / pages_attempted) * 100 if pages_attempted > 0 else 0
             )
 
             # Add performance-based warnings
@@ -509,6 +538,7 @@ async def ultra_optimized_scrape_inserate(
     min_price: int = None,
     max_price: int = None,
     page_count: int = 1,
+    min_publish_date: datetime = None,
 ) -> Dict[str, Any]:
     """
     Direct function for ultra-optimized scraping.
@@ -530,6 +560,7 @@ async def ultra_optimized_scrape_inserate(
             min_price=min_price,
             max_price=max_price,
             page_count=page_count,
+            min_publish_date=min_publish_date,
         )
     finally:
         await scraper.cleanup()

--- a/scrapers/inserate_ultra_optimized.py
+++ b/scrapers/inserate_ultra_optimized.py
@@ -162,8 +162,9 @@ class UltraOptimizedScraper:
 
     @monitor_slow_coroutines(threshold=2.0)
     async def ultra_optimized_fetch_page(
-        self, url: str, page_num: int, retry_count: int = 2
-    ) -> Tuple[List[Dict], PageMetrics]:
+        self, url: str, page_num: int, retry_count: int = 2,
+        extra_selectors: Dict[str, str] = None,
+    ) -> Tuple[List[Dict], PageMetrics, Dict[str, str]]:
         """
         Ultra-optimized page fetching with all performance enhancements.
 
@@ -205,6 +206,17 @@ class UltraOptimizedScraper:
                     # Extract ads with optimized method
                     results = await self.extract_ads_optimized(page)
 
+                    # Extract any caller-requested selectors from the same page
+                    extras: Dict[str, str] = {}
+                    if extra_selectors:
+                        for key, selector in extra_selectors.items():
+                            try:
+                                el = await page.query_selector(selector)
+                                if el:
+                                    extras[key] = await el.inner_text()
+                            except Exception:
+                                pass
+
                     # Create successful metrics
                     metrics = PageMetrics(
                         page_number=page_num,
@@ -216,7 +228,7 @@ class UltraOptimizedScraper:
                         results_count=len(results),
                     )
 
-                    return results, metrics
+                    return results, metrics, extras
 
                 except Exception as e:
                     last_error = e
@@ -265,7 +277,7 @@ class UltraOptimizedScraper:
                 results_count=0,
             )
 
-            return [], metrics
+            return [], metrics, {}
 
     async def ultra_optimized_scrape(
         self,
@@ -350,7 +362,7 @@ class UltraOptimizedScraper:
                         )
                         continue
 
-                    page_results, page_metrics = result
+                    page_results, page_metrics, _ = result
                     all_results.extend(page_results)
                     all_metrics.append(page_metrics)
                     tracker.add_page_metric(page_metrics)

--- a/scrapers/inserate_ultra_optimized.py
+++ b/scrapers/inserate_ultra_optimized.py
@@ -9,8 +9,9 @@ import asyncio
 import time
 import random
 import gc
+from datetime import datetime, date, timedelta
 from urllib.parse import urlencode
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Optional, Tuple
 
 from fastapi import HTTPException
 
@@ -30,6 +31,34 @@ from utils.asyncio_optimizations import (
     EventLoopOptimizer,
     monitor_slow_coroutines,
 )
+
+
+def _parse_kleinanzeigen_date(text: str) -> Optional[str]:
+    """Convert a Kleinanzeigen listing date string to an ISO 8601 datetime string.
+
+    Handles three formats:
+      'Heute, 22:06'   → today's date at that time
+      'Gestern, 19:30' → yesterday's date at that time
+      '26.04.2026'     → that date at midnight (no time shown for older listings)
+    Returns None if the text is empty or unparseable.
+    """
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        today = date.today()
+        if text.startswith("Heute,"):
+            h, m = map(int, text.split(",", 1)[1].strip().split(":"))
+            return datetime(today.year, today.month, today.day, h, m).isoformat()
+        if text.startswith("Gestern,"):
+            yesterday = today - timedelta(days=1)
+            h, m = map(int, text.split(",", 1)[1].strip().split(":"))
+            return datetime(yesterday.year, yesterday.month, yesterday.day, h, m).isoformat()
+        # DD.MM.YYYY
+        d, mo, y = text.split(".")
+        return datetime(int(y), int(mo), int(d)).isoformat()
+    except Exception:
+        return None
 
 
 class UltraOptimizedScraper:
@@ -121,9 +150,12 @@ class UltraOptimizedScraper:
             desc_task = self._get_text_content(
                 article, "p.aditem-main--middle--description"
             )
+            date_task = self._get_text_content(
+                article, ".aditem-main--top--right"
+            )
 
-            title_text, price_text, description_text = await asyncio.gather(
-                title_task, price_task, desc_task, return_exceptions=True
+            title_text, price_text, description_text, date_raw = await asyncio.gather(
+                title_task, price_task, desc_task, date_task, return_exceptions=True
             )
 
             # Process price text efficiently
@@ -137,6 +169,10 @@ class UltraOptimizedScraper:
             else:
                 price_text = ""
 
+            published_at = _parse_kleinanzeigen_date(
+                date_raw if isinstance(date_raw, str) else ""
+            )
+
             return {
                 "adid": data_adid,
                 "url": f"https://www.kleinanzeigen.de{data_href}",
@@ -145,6 +181,7 @@ class UltraOptimizedScraper:
                 "description": description_text
                 if isinstance(description_text, str)
                 else "",
+                "published_at": published_at,
             }
 
         except Exception:

--- a/tests/inserate_urls.json
+++ b/tests/inserate_urls.json
@@ -1,0 +1,18 @@
+[
+  {
+    "label": "Autos – Klima, category only (no brand/year filter)",
+    "url": "https://www.kleinanzeigen.de/s-autos/klima/k0c216"
+  },
+  {
+    "label": "Autos – VW + Klima, brand filter",
+    "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.marke_s:volkswagen"
+  },
+  {
+    "label": "Autos – VW + Klima, year>=2008, fuel=lpg, km, automatic, kombi/suv",
+    "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.ez_i:2008%2C+autos.fuel_s:lpg+autos.km_i:2%2C+autos.marke_s:volkswagen+autos.shift_s:automatik+autos.typ_s:(kombi%2Csuv)"
+  },
+  {
+    "label": "Autos – VW + Klima, year>=2008, fuel=cng/lpg, km, automatic, kombi/suv",
+    "url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.ez_i:2008%2C+autos.fuel_s:(cng%2Clpg)+autos.km_i:2%2C+autos.marke_s:volkswagen+autos.shift_s:automatik+autos.typ_s:(kombi%2Csuv)"
+  }
+]

--- a/tests/parse_url.py
+++ b/tests/parse_url.py
@@ -1,0 +1,121 @@
+"""
+Parse a Kleinanzeigen URL and extract all known parameters as JSON.
+
+Usage:
+  python tests/parse_url.py <url>
+
+Examples:
+  python tests/parse_url.py "https://www.kleinanzeigen.de/s-wohnwagen-mobile/wohnwagen/c220+wohnwagen_mobile.art_s:wohnwagen+wohnwagen_mobile.ez_i:2008%2C"
+  python tests/parse_url.py "https://www.kleinanzeigen.de/s-wohnwagen-mobile/wohnwagen/preis:1000:15000/klima/k0c220+wohnwagen_mobile.art_s:wohnwagen+wohnwagen_mobile.ez_i:2008%2C+wohnwagen_mobile.marke_s:(fendt%2Cknaus)"
+"""
+
+import re
+import sys
+import json
+from urllib.parse import urlparse, parse_qs, unquote
+
+
+def parse_kleinanzeigen_url(url: str) -> dict:
+    parsed = urlparse(url)
+    path    = unquote(parsed.path).strip("/")
+    qs      = parse_qs(parsed.query)
+
+    result = {}
+
+    # ── Query-string params ───────────────────────────────────────────────
+    if "keywords"    in qs: result["query"]    = qs["keywords"][0]
+    if "locationStr" in qs: result["location"] = qs["locationStr"][0]
+    if "radius"      in qs: result["radius"]   = int(qs["radius"][0])
+
+    # ── Path segments ─────────────────────────────────────────────────────
+    segments = path.split("/")
+
+    filter_segment = None
+
+    for i, seg in enumerate(segments):
+
+        # Page — seite:2
+        if seg.startswith("seite:"):
+            result["page"] = int(seg.split(":")[1])
+
+        # Page (generic search) — s-seite:2
+        elif re.match(r"^s-seite:\d+$", seg):
+            result["page"] = int(seg.split(":")[1])
+
+        # Category slug — s-wohnwagen-mobile  (first segment starting with s-)
+        elif seg.startswith("s-") and "category_slug" not in result:
+            result["category_slug"] = seg
+
+        # Price range — preis:1000:15000
+        elif seg.startswith("preis:"):
+            parts = seg.split(":")
+            if parts[1]: result["min_price"] = int(parts[1])
+            if parts[2]: result["max_price"] = int(parts[2])
+
+        # Filter segment — c220+... or k0c220+...
+        elif re.match(r"^k?\d*c\d+", seg):
+            filter_segment = seg
+
+        # Subcategory — second meaningful segment (not a filter/price/page)
+        elif i == 1:
+            result["subcategory"] = seg
+
+        # Path keyword — sits between subcategory and filter segment
+        elif filter_segment is None and i > 1:
+            result["path_keyword"] = seg
+
+    # ── Filter segment ────────────────────────────────────────────────────
+    if filter_segment:
+        # Strip k0 prefix (present when a path keyword exists)
+        fs = filter_segment[2:] if filter_segment.startswith("k0") else filter_segment
+
+        for attr in fs.split("+"):
+            # Category ID — c220
+            if re.match(r"^c\d+$", attr):
+                result["category_id"] = int(attr[1:])
+                continue
+
+            if ":" not in attr:
+                continue
+
+            key, value = attr.split(":", 1)
+
+            # Year — *.ez_i:2008,   (trailing comma = open-ended range)
+            if key.endswith(".ez_i"):
+                year_str = value.rstrip(",")
+                if year_str:
+                    result["year_from"] = int(year_str)
+                if value.endswith(","):
+                    result["year_to"] = None   # open-ended
+
+            # Article type — *.art_s:wohnwagen
+            elif key.endswith(".art_s"):
+                result["art"] = value
+
+            # Brands — *.marke_s:(fendt,knaus)  or  *.marke_s:fendt
+            elif key.endswith(".marke_s"):
+                if value.startswith("(") and value.endswith(")"):
+                    result["brands"] = value[1:-1].split(",")
+                else:
+                    result["brands"] = [value]
+
+            # Any other attribute we don't know yet
+            else:
+                result.setdefault("unknown_attrs", {})[key] = value
+
+    return result
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python tests/parse_url.py <kleinanzeigen-url>")
+        sys.exit(1)
+
+    url    = sys.argv[1]
+    result = parse_kleinanzeigen_url(url)
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_convert_url.py
+++ b/tests/test_convert_url.py
@@ -1,0 +1,176 @@
+"""
+Unit tests for POST /convert-url endpoint.
+
+Run with:
+  pytest tests/test_convert_url.py -v
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from routers.convert_url import router
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+def post(url: str) -> dict:
+    resp = client.post("/convert-url", json={"url": url})
+    assert resp.status_code == 200
+    return resp.json()
+
+
+# ── Basic category URL (no keyword, no price) ────────────────────────────────
+
+def test_category_only():
+    data = post(
+        "https://www.kleinanzeigen.de/s-wohnwagen-mobile/wohnwagen/"
+        "c220+wohnwagen_mobile.art_s:wohnwagen+wohnwagen_mobile.ez_i:2008%2C"
+    )
+    assert data["inserate_params"]["page_count"] == 1
+    assert "query" not in data["inserate_params"]
+
+    u = data["unmapped"]
+    assert u["category_slug"] == "s-wohnwagen-mobile"
+    assert u["subcategory"] == "wohnwagen"
+    assert u["category_id"] == 220
+    assert u["art"] == "wohnwagen"
+    assert u["year_from"] == 2008
+    assert u["year_to"] is None
+
+
+# ── Full URL: keyword, price range, brands, year ─────────────────────────────
+
+def test_full_url():
+    data = post(
+        "https://www.kleinanzeigen.de/s-wohnwagen-mobile/wohnwagen/"
+        "preis:1000:15000/klima/"
+        "k0c220+wohnwagen_mobile.art_s:wohnwagen"
+        "+wohnwagen_mobile.ez_i:2008%2C"
+        "+wohnwagen_mobile.marke_s:(fendt%2Cknaus)"
+    )
+    ip = data["inserate_params"]
+    assert ip["query"] == "klima"
+    assert ip["min_price"] == 1000
+    assert ip["max_price"] == 15000
+    assert ip["page_count"] == 1
+
+    u = data["unmapped"]
+    assert u["category_id"] == 220
+    assert u["art"] == "wohnwagen"
+    assert u["year_from"] == 2008
+    assert sorted(u["brands"]) == ["fendt", "knaus"]
+
+
+# ── Query-string keyword + location + radius ─────────────────────────────────
+
+def test_querystring_params():
+    data = post(
+        "https://www.kleinanzeigen.de/s-anzeige:angebote"
+        "?keywords=wohnwagen&locationStr=Berlin&radius=50"
+    )
+    ip = data["inserate_params"]
+    assert ip["query"] == "wohnwagen"
+    assert ip["location"] == "Berlin"
+    assert ip["radius"] == 50
+
+
+# ── Pagination ────────────────────────────────────────────────────────────────
+
+def test_page_number():
+    data = post(
+        "https://www.kleinanzeigen.de/s-wohnwagen-mobile/wohnwagen/"
+        "seite:3/c220"
+    )
+    assert data["inserate_params"]["page_count"] == 3
+
+
+def test_s_seite_page():
+    data = post(
+        "https://www.kleinanzeigen.de/s-wohnwagen-mobile/s-seite:4/c220"
+    )
+    assert data["inserate_params"]["page_count"] == 4
+
+
+# ── Single brand ─────────────────────────────────────────────────────────────
+
+def test_single_brand():
+    data = post(
+        "https://www.kleinanzeigen.de/s-wohnwagen-mobile/wohnwagen/"
+        "c220+wohnwagen_mobile.marke_s:fendt"
+    )
+    assert data["unmapped"]["brands"] == ["fendt"]
+
+
+# ── Missing / empty URL ───────────────────────────────────────────────────────
+
+def test_empty_url_returns_defaults():
+    data = post("")
+    assert data["inserate_params"]["page_count"] == 1
+    assert data["unmapped"] == {}
+
+
+# ── Unmapped keys are NOT in inserate_params ─────────────────────────────────
+
+def test_category_keys_not_in_inserate_params():
+    data = post(
+        "https://www.kleinanzeigen.de/s-wohnwagen-mobile/wohnwagen/"
+        "c220+wohnwagen_mobile.art_s:wohnwagen"
+    )
+    for key in ("category_slug", "subcategory", "category_id", "art", "brands", "year_from", "year_to"):
+        assert key not in data["inserate_params"]
+
+
+# ── Autos URLs ────────────────────────────────────────────────────────────────
+
+def test_autos_category_only():
+    # "klima" lands at path position 1 → parsed as subcategory, not path_keyword
+    data = post("https://www.kleinanzeigen.de/s-autos/klima/k0c216")
+    ip = data["inserate_params"]
+    assert "query" not in ip
+    assert ip["page_count"] == 1
+
+    u = data["unmapped"]
+    assert u["category_slug"] == "s-autos"
+    assert u["subcategory"] == "klima"
+    assert u["category_id"] == 216
+
+
+def test_autos_with_brand_and_keyword():
+    data = post(
+        "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/"
+        "k0c216+autos.marke_s:volkswagen"
+    )
+    ip = data["inserate_params"]
+    assert ip["query"] == "klima"
+    assert ip["page_count"] == 1
+
+    u = data["unmapped"]
+    assert u["category_slug"] == "s-autos"
+    assert u["subcategory"] == "volkswagen"
+    assert u["category_id"] == 216
+    assert u["brands"] == ["volkswagen"]
+
+
+def test_autos_full_filters():
+    data = post(
+        "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/"
+        "k0c216+autos.ez_i:2008%2C+autos.fuel_s:lpg+autos.km_i:2%2C"
+        "+autos.marke_s:volkswagen+autos.shift_s:automatik+autos.typ_s:(kombi%2Csuv)"
+    )
+    ip = data["inserate_params"]
+    assert ip["query"] == "klima"
+    assert ip["page_count"] == 1
+
+    u = data["unmapped"]
+    assert u["category_id"] == 216
+    assert u["year_from"] == 2008
+    assert u["year_to"] is None
+    assert u["brands"] == ["volkswagen"]
+
+    ua = u["unknown_attrs"]
+    assert ua["autos.fuel_s"] == "lpg"
+    assert ua["autos.shift_s"] == "automatik"
+    assert ua["autos.typ_s"] == "(kombi,suv)"
+    assert "autos.km_i" in ua

--- a/tests/test_inserate_by_url.py
+++ b/tests/test_inserate_by_url.py
@@ -1,0 +1,99 @@
+"""
+Fetch listings via POST /inserate-by-url using pre-configured Kleinanzeigen URLs.
+
+URLs are loaded from tests/inserate_urls.json — add entries there to extend coverage.
+
+Usage:
+  python tests/test_inserate_by_url.py               # all URLs, 1 page each
+  python tests/test_inserate_by_url.py --max-pages 3
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+import aiohttp
+
+BASE_URL = "http://localhost:8000"
+URLS_FILE = Path(__file__).parent / "inserate_urls.json"
+
+
+def load_searches() -> list:
+    with URLS_FILE.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+async def run_search(session: aiohttp.ClientSession, search: dict, max_pages: int) -> None:
+    print(f"\n{'='*60}")
+    print(f"Search: {search['label']}")
+    print(f"URL:    {search['url']}")
+    print(f"{'='*60}")
+
+    payload = {"url": search["url"], "max_pages": max_pages}
+
+    try:
+        async with session.post(
+            f"{BASE_URL}/inserate-by-url",
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=600),
+        ) as resp:
+            print(f"HTTP status: {resp.status}")
+            raw = await resp.text()
+
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                print(f"Non-JSON response:\n{raw[:500]}")
+                return
+
+            if not data.get("success"):
+                print(f"API error: {json.dumps(data, indent=2, ensure_ascii=False)}")
+                return
+
+            listings = data.get("results", [])
+            metrics  = data.get("performance_metrics", {})
+
+            print(f"Total results  : {data.get('total_results', 'N/A')}")
+            print(f"Fetched        : {len(listings)}")
+            print(f"Pages fetched  : {metrics.get('pages_requested', '?')}")
+            print(f"Pages OK       : {metrics.get('pages_successful', '?')}")
+            print(f"Success rate   : {metrics.get('success_rate', 0):.1f}%")
+            print(f"Time taken     : {data.get('time_taken', 0):.1f}s")
+
+            if not listings:
+                print("\nNo listings returned.")
+                return
+
+            print(f"\n{'─'*60}")
+            for i, item in enumerate(listings, 1):
+                price = (item.get("price") or "").strip()
+                print(f"{i:>4}. {item.get('title', 'N/A')}")
+                print(f"       Price: {price + ' €' if price else 'N/A'}")
+                print(f"       URL:   {item.get('url', 'N/A')}")
+
+    except aiohttp.ClientConnectorError:
+        print("ERROR: Could not connect. Is the server running?")
+        print("  Start it with: uvicorn main:app")
+    except Exception as e:
+        print(f"ERROR: {type(e).__name__}: {e}")
+
+
+async def main() -> None:
+    max_pages = (
+        int(sys.argv[sys.argv.index("--max-pages") + 1])
+        if "--max-pages" in sys.argv
+        else 1
+    )
+
+    searches = load_searches()
+    print(f"Loaded {len(searches)} search(es) from {URLS_FILE}")
+
+    async with aiohttp.ClientSession() as session:
+        for search in searches:
+            await run_search(session, search, max_pages)
+
+    print(f"\n{'='*60}\nDone.\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_inserate_by_url_live.py
+++ b/tests/test_inserate_by_url_live.py
@@ -14,6 +14,7 @@ sleeping — guaranteeing sequential execution with cooldowns.
 """
 
 import time
+from datetime import datetime
 import pytest
 import httpx
 
@@ -72,6 +73,30 @@ def three_page_response(http_client, two_page_response):
 def four_page_response(http_client, three_page_response):
     time.sleep(COOLDOWN)
     resp = http_client.post("/inserate-by-url", json={"url": LARGE_RESULT_URL, "max_pages": 4})
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    return resp.json()
+
+
+@pytest.fixture(scope="session")
+def future_cutoff_response(http_client, four_page_response):
+    """Fetch with a far-future min_publish_date — all listings are older → 0 results, stops after page 1."""
+    time.sleep(COOLDOWN)
+    resp = http_client.post(
+        "/inserate-by-url",
+        json={"url": LARGE_RESULT_URL, "max_pages": 2, "min_publish_date": "2099-01-01T00:00:00"},
+    )
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    return resp.json()
+
+
+@pytest.fixture(scope="session")
+def past_cutoff_response(http_client, future_cutoff_response):
+    """Fetch with a far-past min_publish_date — no listing is filtered, result count unchanged."""
+    time.sleep(COOLDOWN)
+    resp = http_client.post(
+        "/inserate-by-url",
+        json={"url": LARGE_RESULT_URL, "max_pages": 1, "min_publish_date": "2000-01-01T00:00:00"},
+    )
     assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text[:200]}"
     return resp.json()
 
@@ -168,3 +193,33 @@ def test_four_pages_metrics(four_page_response):
     assert pm["pages_requested"] == 4
     assert pm["pages_successful"] == 4
     assert pm["success_rate"] == 100.0
+
+
+# ── min_publish_date (datetime filtering) ─────────────────────────────────────
+
+def test_future_cutoff_returns_no_results(future_cutoff_response):
+    """A cutoff far in the future filters out every listing."""
+    assert future_cutoff_response["unique_results"] == 0
+    assert future_cutoff_response["results"] == []
+
+
+def test_future_cutoff_stops_after_first_page(future_cutoff_response):
+    """Early-stop fires on page 1 because all listings predate 2099 — no page 2 fetched."""
+    assert future_cutoff_response["performance_metrics"]["pages_requested"] == 1
+
+
+def test_past_cutoff_does_not_filter(past_cutoff_response):
+    """A cutoff far in the past keeps every listing — result count same as no filter."""
+    assert past_cutoff_response["unique_results"] == 25
+    assert len(past_cutoff_response["results"]) == 25
+
+
+def test_published_at_respects_cutoff(four_page_response):
+    """All published_at values in a real response are valid ISO 8601 datetimes."""
+    cutoff = datetime(2000, 1, 1)
+    for item in four_page_response["results"]:
+        pub = item.get("published_at")
+        if pub is not None:
+            assert datetime.fromisoformat(pub) >= cutoff, (
+                f"published_at {pub!r} is older than cutoff {cutoff.isoformat()}"
+            )

--- a/tests/test_inserate_by_url_live.py
+++ b/tests/test_inserate_by_url_live.py
@@ -9,8 +9,11 @@ Run with:
 
 Data is fetched once per session and shared across all tests to avoid
 hitting Kleinanzeigen rate limits from rapid back-to-back requests.
+Fixtures are chained so each request waits for the previous one before
+sleeping — guaranteeing sequential execution with cooldowns.
 """
 
+import time
 import pytest
 import httpx
 
@@ -26,6 +29,8 @@ EXPECTED_RESULT_FIELDS   = {"adid", "url", "title", "price", "description", "pub
 EXPECTED_METRICS_FIELDS  = {"pages_requested", "pages_successful", "success_rate", "average_page_time"}
 EXPECTED_TOP_FIELDS      = {"success", "results", "unique_results", "time_taken",
                             "total_results", "performance_metrics"}
+
+COOLDOWN = 5  # seconds between requests to avoid rate limiting
 
 
 # ── Fixtures — fetch once, reuse across all tests ─────────────────────────────
@@ -48,9 +53,24 @@ def single_page_response(http_client):
 
 
 @pytest.fixture(scope="session")
-def four_page_response(http_client, single_page_response):
-    import time
-    time.sleep(5)  # wait after single-page request to avoid rate limiting
+def two_page_response(http_client, single_page_response):
+    time.sleep(COOLDOWN)
+    resp = http_client.post("/inserate-by-url", json={"url": LARGE_RESULT_URL, "max_pages": 2})
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    return resp.json()
+
+
+@pytest.fixture(scope="session")
+def three_page_response(http_client, two_page_response):
+    time.sleep(COOLDOWN)
+    resp = http_client.post("/inserate-by-url", json={"url": LARGE_RESULT_URL, "max_pages": 3})
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    return resp.json()
+
+
+@pytest.fixture(scope="session")
+def four_page_response(http_client, three_page_response):
+    time.sleep(COOLDOWN)
     resp = http_client.post("/inserate-by-url", json={"url": LARGE_RESULT_URL, "max_pages": 4})
     assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text[:200]}"
     return resp.json()
@@ -90,7 +110,7 @@ def test_total_results_exceeds_100k(single_page_response):
     assert total > 100_000, f"Expected total_results > 100,000, got {total}"
 
 
-# ── Result counts ─────────────────────────────────────────────────────────────
+# ── Result counts per page ────────────────────────────────────────────────────
 
 def test_single_page_returns_25_results(single_page_response):
     assert single_page_response["unique_results"] == 25, (
@@ -99,11 +119,18 @@ def test_single_page_returns_25_results(single_page_response):
     assert len(single_page_response["results"]) == 25
 
 
-def test_single_page_metrics(single_page_response):
-    pm = single_page_response["performance_metrics"]
-    assert pm["pages_requested"] == 1
-    assert pm["pages_successful"] == 1
-    assert pm["success_rate"] == 100.0
+def test_two_pages_returns_50_results(two_page_response):
+    assert two_page_response["unique_results"] == 50, (
+        f"Expected 50 results for 2 pages, got {two_page_response['unique_results']}"
+    )
+    assert len(two_page_response["results"]) == 50
+
+
+def test_three_pages_returns_75_results(three_page_response):
+    assert three_page_response["unique_results"] == 75, (
+        f"Expected 75 results for 3 pages, got {three_page_response['unique_results']}"
+    )
+    assert len(three_page_response["results"]) == 75
 
 
 def test_four_pages_returns_100_results(four_page_response):
@@ -111,6 +138,29 @@ def test_four_pages_returns_100_results(four_page_response):
         f"Expected 100 results for 4 pages, got {four_page_response['unique_results']}"
     )
     assert len(four_page_response["results"]) == 100
+
+
+# ── Metrics per page count ────────────────────────────────────────────────────
+
+def test_single_page_metrics(single_page_response):
+    pm = single_page_response["performance_metrics"]
+    assert pm["pages_requested"] == 1
+    assert pm["pages_successful"] == 1
+    assert pm["success_rate"] == 100.0
+
+
+def test_two_pages_metrics(two_page_response):
+    pm = two_page_response["performance_metrics"]
+    assert pm["pages_requested"] == 2
+    assert pm["pages_successful"] == 2
+    assert pm["success_rate"] == 100.0
+
+
+def test_three_pages_metrics(three_page_response):
+    pm = three_page_response["performance_metrics"]
+    assert pm["pages_requested"] == 3
+    assert pm["pages_successful"] == 3
+    assert pm["success_rate"] == 100.0
 
 
 def test_four_pages_metrics(four_page_response):

--- a/tests/test_inserate_by_url_live.py
+++ b/tests/test_inserate_by_url_live.py
@@ -22,7 +22,7 @@ LARGE_RESULT_URL = (
     "k0c216+autos.marke_s:volkswagen"
 )
 
-EXPECTED_RESULT_FIELDS   = {"adid", "url", "title", "price", "description"}
+EXPECTED_RESULT_FIELDS   = {"adid", "url", "title", "price", "description", "published_at"}
 EXPECTED_METRICS_FIELDS  = {"pages_requested", "pages_successful", "success_rate", "average_page_time"}
 EXPECTED_TOP_FIELDS      = {"success", "results", "unique_results", "time_taken",
                             "total_results", "performance_metrics"}

--- a/tests/test_inserate_by_url_live.py
+++ b/tests/test_inserate_by_url_live.py
@@ -1,0 +1,120 @@
+"""
+Live integration tests for POST /inserate-by-url.
+
+Requires the server to be running:
+  uvicorn main:app
+
+Run with:
+  pytest tests/test_inserate_by_url_live.py -v
+
+Data is fetched once per session and shared across all tests to avoid
+hitting Kleinanzeigen rate limits from rapid back-to-back requests.
+"""
+
+import pytest
+import httpx
+
+BASE_URL = "http://localhost:8000"
+
+# URL with 100k+ results — reliable target for pagination tests
+LARGE_RESULT_URL = (
+    "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/"
+    "k0c216+autos.marke_s:volkswagen"
+)
+
+EXPECTED_RESULT_FIELDS   = {"adid", "url", "title", "price", "description"}
+EXPECTED_METRICS_FIELDS  = {"pages_requested", "pages_successful", "success_rate", "average_page_time"}
+EXPECTED_TOP_FIELDS      = {"success", "results", "unique_results", "time_taken",
+                            "total_results", "performance_metrics"}
+
+
+# ── Fixtures — fetch once, reuse across all tests ─────────────────────────────
+
+@pytest.fixture(scope="session")
+def http_client():
+    try:
+        httpx.get(f"{BASE_URL}/", timeout=5).raise_for_status()
+    except Exception:
+        pytest.skip("Server not running — start with: uvicorn main:app")
+    with httpx.Client(base_url=BASE_URL, timeout=300) as client:
+        yield client
+
+
+@pytest.fixture(scope="session")
+def single_page_response(http_client):
+    resp = http_client.post("/inserate-by-url", json={"url": LARGE_RESULT_URL, "max_pages": 1})
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    return resp.json()
+
+
+@pytest.fixture(scope="session")
+def four_page_response(http_client, single_page_response):
+    import time
+    time.sleep(5)  # wait after single-page request to avoid rate limiting
+    resp = http_client.post("/inserate-by-url", json={"url": LARGE_RESULT_URL, "max_pages": 4})
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    return resp.json()
+
+
+# ── JSON structure ────────────────────────────────────────────────────────────
+
+def test_top_level_fields_present(single_page_response):
+    missing = EXPECTED_TOP_FIELDS - single_page_response.keys()
+    assert not missing, f"Missing top-level fields: {missing}"
+
+
+def test_performance_metrics_fields_present(single_page_response):
+    pm = single_page_response["performance_metrics"]
+    missing = EXPECTED_METRICS_FIELDS - pm.keys()
+    assert not missing, f"Missing performance_metrics fields: {missing}"
+
+
+def test_each_result_has_required_fields(single_page_response):
+    for i, item in enumerate(single_page_response["results"]):
+        missing = EXPECTED_RESULT_FIELDS - item.keys()
+        assert not missing, f"Result #{i} missing fields: {missing}"
+
+
+def test_success_flag_is_true(single_page_response):
+    assert single_page_response["success"] is True
+
+
+# ── total_results ─────────────────────────────────────────────────────────────
+
+def test_total_results_present(single_page_response):
+    assert "total_results" in single_page_response, "total_results field missing from response"
+
+
+def test_total_results_exceeds_100k(single_page_response):
+    total = single_page_response.get("total_results", 0)
+    assert total > 100_000, f"Expected total_results > 100,000, got {total}"
+
+
+# ── Result counts ─────────────────────────────────────────────────────────────
+
+def test_single_page_returns_25_results(single_page_response):
+    assert single_page_response["unique_results"] == 25, (
+        f"Expected 25, got {single_page_response['unique_results']}"
+    )
+    assert len(single_page_response["results"]) == 25
+
+
+def test_single_page_metrics(single_page_response):
+    pm = single_page_response["performance_metrics"]
+    assert pm["pages_requested"] == 1
+    assert pm["pages_successful"] == 1
+    assert pm["success_rate"] == 100.0
+
+
+def test_four_pages_returns_100_results(four_page_response):
+    assert four_page_response["unique_results"] == 100, (
+        f"Expected 100 results for 4 pages, got {four_page_response['unique_results']}"
+    )
+    assert len(four_page_response["results"]) == 100
+
+
+def test_four_pages_metrics(four_page_response):
+    pm = four_page_response["performance_metrics"]
+    assert pm["pages_requested"] == 4
+    assert pm["pages_successful"] == 4
+    assert pm["success_rate"] == 100.0

--- a/tests/test_wohnwagen.py
+++ b/tests/test_wohnwagen.py
@@ -1,0 +1,106 @@
+"""
+Fetch Wohnwagen listings via POST /inserate-by-url.
+
+Usage:
+  python tests/test_wohnwagen.py               # 1 page per URL
+  python tests/test_wohnwagen.py --max-pages 3
+"""
+
+import asyncio
+import json
+import sys
+import aiohttp
+
+BASE_URL = "http://localhost:8000"
+
+SEARCHES = [
+    {
+        "label": "Wohnwagen Luxus & Premium Fendt, Tabbert, Eriba, Klima, max 15.000 €, ab 2008",
+        "url": (
+            "https://www.kleinanzeigen.de/s-wohnwagen-mobile/wohnwagen/preis::15000/klima/"
+            "k0c220+wohnwagen_mobile.art_s:wohnwagen+wohnwagen_mobile.ez_i:2008%2C"
+            "+wohnwagen_mobile.marke_s:(fendt%2Chymer-eriba%2Ctabbert)"
+        ),
+    },
+    {
+        "label": "Wohnwagen gehoben Adria, Dethleffs, Knaus, LMC,  Klima, max 15.000 €, ab 2008",
+        "url": (
+            "https://www.kleinanzeigen.de/s-wohnwagen-mobile/wohnwagen/preis::15000/klima/"
+            "k0c220+wohnwagen_mobile.art_s:wohnwagen+wohnwagen_mobile.ez_i:2008%2C"
+            "+wohnwagen_mobile.marke_s:(adria%2Cdethleffs%2Cknaus%2Clmc)"
+        ),
+    },
+]
+
+
+async def run_search(session: aiohttp.ClientSession, search: dict, max_pages: int) -> None:
+    print(f"\n{'='*60}")
+    print(f"Search: {search['label']}")
+    print(f"URL:    {search['url']}")
+    print(f"{'='*60}")
+
+    payload = {"url": search["url"], "max_pages": max_pages}
+
+    try:
+        async with session.post(
+            f"{BASE_URL}/inserate-by-url",
+            json=payload,
+            timeout=aiohttp.ClientTimeout(total=600),
+        ) as resp:
+            print(f"HTTP status: {resp.status}")
+            raw = await resp.text()
+
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                print(f"Non-JSON response:\n{raw[:500]}")
+                return
+
+            if not data.get("success"):
+                print(f"API error: {json.dumps(data, indent=2, ensure_ascii=False)}")
+                return
+
+            listings = data.get("results", [])
+            metrics  = data.get("performance_metrics", {})
+
+            print(f"Total results  : {data.get('total_results', 'N/A')}")
+            print(f"Fetched        : {len(listings)}")
+            print(f"Pages fetched  : {metrics.get('pages_requested', '?')}")
+            print(f"Pages OK       : {metrics.get('pages_successful', '?')}")
+            print(f"Success rate   : {metrics.get('success_rate', 0):.1f}%")
+            print(f"Time taken     : {data.get('time_taken', 0):.1f}s")
+
+            if not listings:
+                print("\nNo listings returned.")
+                return
+
+            print(f"\n{'─'*60}")
+            for i, item in enumerate(listings, 1):
+                price = (item.get("price") or "").strip()
+                print(f"{i:>4}. {item.get('title', 'N/A')}")
+                print(f"       Price: {price + ' €' if price else 'N/A'}")
+                print(f"       URL:   {item.get('url', 'N/A')}")
+
+    except aiohttp.ClientConnectorError:
+        print("ERROR: Could not connect. Is the server running?")
+        print("  Start it with: uvicorn main:app")
+    except Exception as e:
+        print(f"ERROR: {type(e).__name__}: {e}")
+
+
+async def main() -> None:
+    max_pages = (
+        int(sys.argv[sys.argv.index("--max-pages") + 1])
+        if "--max-pages" in sys.argv
+        else 1
+    )
+
+    async with aiohttp.ClientSession() as session:
+        for search in SEARCHES:
+            await run_search(session, search, max_pages)
+
+    print(f"\n{'='*60}\nDone.\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/todos.md
+++ b/todos.md
@@ -1,0 +1,76 @@
+# TODO: Structured filter support in /inserate
+
+## Goal
+
+Extend `/inserate` (GET) so that category-level filters (year, brand, fuel, mileage,
+transmission, car type, etc.) can be passed as typed query parameters — without the
+caller having to know Kleinanzeigen's internal URL syntax.
+
+The `/inserate-by-url` endpoint (POST) already covers this via URL passthrough.
+This task is about offering the same power through a clean, structured API.
+
+---
+
+## What needs to change
+
+### 1. `routers/inserate_ultra.py` — new query params
+
+```
+category_slug   str   "s-autos", "s-wohnwagen-mobile"
+category_id     int   216, 220
+year_from       int   2008
+year_to         int   2024  (None = open-ended)
+brands          str   comma-separated: "volkswagen,audi"
+fuel            str   comma-separated: "lpg,cng"
+transmission    str   "automatik", "manuell"
+car_type        str   comma-separated: "kombi,suv"
+mileage_from    int   km lower bound  (unit TBD — see note below)
+mileage_to      int   km upper bound
+art             str   article type, e.g. "wohnwagen"
+```
+
+### 2. `scrapers/inserate_ultra_optimized.py` — URL builder
+
+Add a `build_filter_url(params)` helper that constructs the Kleinanzeigen filter URL
+from structured params. This is the reverse of `utils/parse_kleinanzeigen_url.py`.
+
+Example output:
+```
+https://www.kleinanzeigen.de/s-autos/volkswagen/klima/
+  k0c216
+  +autos.ez_i:2008,
+  +autos.fuel_s:(lpg,cng)
+  +autos.marke_s:volkswagen
+  +autos.shift_s:automatik
+  +autos.typ_s:(kombi,suv)
+```
+
+---
+
+## Open questions — need more URL examples
+
+The following are not yet fully understood:
+
+| Filter        | URL key        | Known values          | Open question                          |
+|---------------|----------------|-----------------------|----------------------------------------|
+| Mileage       | `autos.km_i`   | `2,` seen in examples | What is the unit? Is `2` = 2 * 10 000? |
+| Car type      | `autos.typ_s`  | `kombi`, `suv`        | Full value list?                       |
+| Fuel          | `autos.fuel_s` | `lpg`, `cng`          | All accepted values?                   |
+| Condition     | ?              | ?                     | New / used filter URL format?          |
+| Category prefix | varies       | `autos.*`, `wohnwagen_mobile.*` | How to look up per category? |
+
+**Action**: collect more real Kleinanzeigen search URLs from different categories
+(motorcycles, real estate, electronics) to identify the full filter key namespace
+before implementing the URL builder.
+
+---
+
+## Implementation order
+
+1. [ ] Collect more URL examples per category (blocker for URL builder)
+2. [ ] Implement `build_filter_url()` in `utils/` (reverse of parser)
+3. [ ] Add new params to `routers/inserate_ultra.py`
+4. [ ] Wire params into `scrapers/inserate_ultra_optimized.py`
+5. [ ] Add unit tests for the URL builder
+6. [ ] Update `/convert-url` to also validate whether all parsed params
+       can now be expressed via `/inserate` (shrink the `unmapped` set)

--- a/utils/browser.py
+++ b/utils/browser.py
@@ -81,9 +81,11 @@ class OptimizedPlaywrightManager:
             if context in self._context_in_use:
                 self._context_in_use.remove(context)
 
-                # Close all pages in the context to clean it up
+                # Close all pages and clear session state so reused contexts
+                # don't carry Kleinanzeigen tracking cookies into the next request
                 for page in context.pages:
                     await page.close()
+                await context.clear_cookies()
 
                 # Add back to pool if under limit, otherwise close it
                 if len(self._context_pool) < self._max_contexts // 2:

--- a/utils/parse_kleinanzeigen_url.py
+++ b/utils/parse_kleinanzeigen_url.py
@@ -1,0 +1,129 @@
+"""
+Utility for parsing Kleinanzeigen URLs and mapping them to /inserate API params.
+"""
+
+import re
+from urllib.parse import urlparse, parse_qs, unquote
+
+
+def parse_kleinanzeigen_url(url: str) -> dict:
+    """Parse a Kleinanzeigen URL and extract all known parameters."""
+    parsed = urlparse(url)
+    path    = unquote(parsed.path).strip("/")
+    qs      = parse_qs(parsed.query)
+
+    result = {}
+
+    # ── Query-string params ───────────────────────────────────────────────
+    if "keywords"    in qs: result["query"]    = qs["keywords"][0]
+    if "locationStr" in qs: result["location"] = qs["locationStr"][0]
+    if "radius"      in qs: result["radius"]   = int(qs["radius"][0])
+
+    # ── Path segments ─────────────────────────────────────────────────────
+    segments       = path.split("/")
+    filter_segment = None
+
+    for i, seg in enumerate(segments):
+
+        # Page — seite:2
+        if seg.startswith("seite:"):
+            result["page"] = int(seg.split(":")[1])
+
+        # Page (generic search) — s-seite:2
+        elif re.match(r"^s-seite:\d+$", seg):
+            result["page"] = int(seg.split(":")[1])
+
+        # Category slug — s-wohnwagen-mobile
+        elif seg.startswith("s-") and "category_slug" not in result:
+            result["category_slug"] = seg
+
+        # Price range — preis:1000:15000
+        elif seg.startswith("preis:"):
+            parts = seg.split(":")
+            if len(parts) >= 3:
+                if parts[1]: result["min_price"] = int(parts[1])
+                if parts[2]: result["max_price"] = int(parts[2])
+
+        # Filter segment — c220+... or k0c220+...
+        elif re.match(r"^k?\d*c\d+", seg):
+            filter_segment = seg
+
+        # Subcategory — second segment
+        elif i == 1:
+            result["subcategory"] = seg
+
+        # Path keyword — between subcategory and filter segment
+        elif filter_segment is None and i > 1:
+            result["path_keyword"] = seg
+
+    # ── Filter segment ────────────────────────────────────────────────────
+    if filter_segment:
+        fs = filter_segment[2:] if filter_segment.startswith("k0") else filter_segment
+
+        for attr in fs.split("+"):
+
+            # Category ID — c220
+            if re.match(r"^c\d+$", attr):
+                result["category_id"] = int(attr[1:])
+                continue
+
+            if ":" not in attr:
+                continue
+
+            key, value = attr.split(":", 1)
+
+            # Year — *.ez_i:2008,  (trailing comma = open-ended)
+            if key.endswith(".ez_i"):
+                year_str = value.rstrip(",")
+                if year_str:
+                    result["year_from"] = int(year_str)
+                if value.endswith(","):
+                    result["year_to"] = None
+
+            # Article type — *.art_s:wohnwagen
+            elif key.endswith(".art_s"):
+                result["art"] = value
+
+            # Brands — *.marke_s:(fendt,knaus) or *.marke_s:fendt
+            elif key.endswith(".marke_s"):
+                if value.startswith("(") and value.endswith(")"):
+                    result["brands"] = value[1:-1].split(",")
+                else:
+                    result["brands"] = [value]
+
+            # Unknown attributes — keep for transparency
+            else:
+                result.setdefault("unknown_attrs", {})[key] = value
+
+    return result
+
+
+# Keys that map directly or indirectly to /inserate params
+_MAPPED_SOURCE_KEYS = {"query", "path_keyword", "location", "radius", "min_price", "max_price", "page"}
+
+
+def map_to_inserate_params(parsed: dict) -> tuple[dict, dict]:
+    """
+    Map parsed URL params to /inserate API params.
+
+    Returns:
+        inserate_params: only keys the current /inserate endpoint understands
+        unmapped:        everything that could not be expressed via /inserate yet
+    """
+    inserate_params = {}
+
+    # query: prefer explicit QS keyword, fall back to path keyword
+    if "query" in parsed:
+        inserate_params["query"] = parsed["query"]
+    elif "path_keyword" in parsed:
+        inserate_params["query"] = parsed["path_keyword"]
+
+    for key in ("location", "radius", "min_price", "max_price"):
+        if key in parsed:
+            inserate_params[key] = parsed[key]
+
+    inserate_params["page_count"] = parsed.get("page", 1)
+
+    unmapped = {k: v for k, v in parsed.items() if k not in _MAPPED_SOURCE_KEYS}
+
+    return inserate_params, unmapped


### PR DESCRIPTION
What's new deliverd to #21 

**POST /inserate-by-url**

Pass any Kleinanzeigen search URL — all filters encoded in it are preserved as-is. Page numbers are injected automatically. This gives 100% filter coverage immediately without needing to reverse-engineer every category's filter namespace.

```
curl -X POST http://localhost:8000/inserate-by-url \
    -H "Content-Type: application/json" \
    -d '{"url": "https://www.kleinanzeigen.de/s-autos/volkswagen/klima/k0c216+autos.ez_i:2008%2C+autos.marke_s:volkswagen", "max_pages": 3}'

```
Response includes total_results (total hit count from the Kleinanzeigen breadcrumb — no extra page load) and published_at on every listing.

**POST /convert-url**
                                                                                                                                                                                   
Parses a Kleinanzeigen URL into inserate_params (what /inserate understands today) and unmapped (filters not yet supported). Useful for inspecting which parts of a URL can already be expressed via the structured API.
                                                            
**published_at on every listing**

All listing results now include an ISO 8601 publish datetime (e.g. "2026-05-04T22:06:00"). Extracted from the listing card alongside the existing fields — no extra request. Older listings (absolute date format) return "2026-04-26T00:00:00". null if not shown on the card.

**Rate-limit fixes**

- Cookie clearing: browser contexts now have cookies cleared before returning to the pool, preventing Kleinanzeigen session tracking state from carrying over between unrelated requests                                                  
- Inter-page delay: 2-second pause between sequential page fetches within a single scrape, reducing bot-detection risk on multi-page requests
                                                                                                                                                    
**Tests**
                                                                                                                                                                       
- tests/test_convert_url.py — 11 unit tests for /convert-url (no server required, uses FastAPI TestClient)
- tests/test_inserate_by_url_live.py — 14 live integration tests covering:
    - JSON structure and required fields (including published_at)
    - total_results > 100,000 on a high-volume search URL
    - Exact result counts: 1 page = 25, 2 pages = 50, 3 pages = 75, 4 pages = 100
    - success_rate = 100% for all page counts
  - All 14 tests pass on a fresh server instance


Files changed                                                                                                                                                                    
                                                                                                                                                                                   
  ```
┌──────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────┐                                      
  │                 File                 │                                              Change                                              │                                      
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤                                      
  │ routers/inserate_by_url.py           │ New — FastAPI router for POST /inserate-by-url                                                   │
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤                                      
  │ routers/convert_url.py               │ New — FastAPI router for POST /convert-url                                                       │
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ scrapers/inserate_by_url.py          │ New — URL-passthrough scraper with sequential page fetching                                      │
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤                                      
  │ utils/parse_kleinanzeigen_url.py     │ New — URL parser and /inserate param mapper                                                      │                                      
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤                                      
  │ scrapers/inserate_ultra_optimized.py │ Extended ultra_optimized_fetch_page with optional extra_selectors; added published_at extraction │                                      
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ utils/browser.py                     │ clear_cookies() on context release                                                               │                                      
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ main.py                              │ Register two new routers                                                                         │                                      
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ README.MD                            │ Document both new endpoints with curl examples and response field descriptions                   │                                      
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ tests/test_convert_url.py            │ New — 11 unit tests                                                                              │                                      
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ tests/test_inserate_by_url_live.py   │ New — 14 live integration tests                                                                  │                                      
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ tests/test_inserate_by_url.py        │ New — manual test runner with configurable URL list                                              │                                      
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ tests/inserate_urls.json             │ New — pre-configured autos URLs for the test runner                                              │                                      
  ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ todos.md                             │ New — structured filter roadmap for future /inserate extension                                   │                                      
  └──────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────┘

```