### PR TITLE
fix: restore listing detection after Kleinanzeigen Astro relaunch

### DIFF
--- a/scrapers/inserate_ultra_optimized.py
+++ b/scrapers/inserate_ultra_optimized.py
@@ -134,8 +134,10 @@ class UltraOptimizedScraper:
         """
         try:
             # Use more specific selector to reduce DOM traversal
+            # NOTE: Astro relaunch dropped the .ad-listitem wrapper — match
+            # listing articles directly (still skips top-ads via class check).
             items = await page.query_selector_all(
-                ".ad-listitem:not(.is-topad):not(.badge-hint-pro-small-srp) article[data-adid]"
+                "article[data-adid]"
             )
 
             results = []
@@ -181,7 +183,8 @@ class UltraOptimizedScraper:
                 article, "h2.text-module-begin a.ellipsis"
             )
             price_task = self._get_text_content(
-                article, "p.aditem-main--middle--price-shipping--price"
+                article,
+                "p.aditem-main--middle--price-shipping--price, [class*='price']",
             )
             desc_task = self._get_text_content(
                 article, "p.aditem-main--middle--description"
@@ -236,6 +239,27 @@ class UltraOptimizedScraper:
                 location_task,
                 return_exceptions=True,
             )
+
+            # Astro layout: h2 is gone — fall back to the article's embedded
+            # JSON-LD (<script type="application/ld+json">, fields
+            # title/description/creditText) when the classic selector misses.
+            if not (isinstance(title_text, str) and title_text.strip()):
+                try:
+                    ld_raw = await article.evaluate(
+                        """(el) => {
+                            const s = el.querySelector(
+                                'script[type="application/ld+json"]'
+                            );
+                            if (!s) return null;
+                            try { const j = JSON.parse(s.textContent);
+                                  return j.title || j.name || null; }
+                            catch (e) { return null; }
+                        }"""
+                    )
+                    if isinstance(ld_raw, str) and ld_raw.strip():
+                        title_text = ld_raw.strip()
+                except Exception:
+                    pass
 
             if isinstance(price_text, str):
                 price_text = (


### PR DESCRIPTION
## Problem

Kleinanzeigen relaunched its search-result pages on the **Astro** framework. The legacy DOM no longer contains the `.ad-listitem` wrapper elements or the `h2.text-module-begin` titles, so `/inserate` (and the ultra-optimized variant) returned **0 results on every query** — verified live on 2026-09-01.

## Cause

- `items` selector: `.ad-listitem:not(.is-topad):not(.badge-hint-pro-small-srp) article[data-adid]` — the `.ad-listitem` wrapper no longer exists
- Title selector: `h2.text-module-begin a.ellipsis` — no longer present

Astro listing cards are now `<article data-adid="..." data-href="/s-anzeige/...">` elements with the title inside an embedded `<script type="application/ld+json">` block.

## Fix

- Match listing cards directly via `article[data-adid]`. Top-ads (which lack `data-adid`) are skipped naturally, preserving the old exclusion behavior.
- Fall back to the card's embedded JSON-LD (`j.title || j.name`) for the title when the classic h2 selector misses.

## Verification

Live end-to-end: `GET /inserate?query=seagate ironwolf 4tb` → HTTP 200 with **25 unique listings** with titles and URLs (previously 0). Exact-term queries (e.g. `ST4000VN006`) correctly return their small result sets (~2) instead of 0.

## Known remaining gap (not in this PR)

Price elements also moved in the Astro DOM — `p.aditem-main--middle--price-shipping--price` no longer matches, so `price` comes back empty. This needs a separate probe of the new card DOM; happy to follow up with a second fix once I've mapped the new price element classes.