### PR TITLE
feat: support external browser via BROWSER_CDP_URL (CDP connect)

### DIFF
--- a/utils/browser.py
+++ b/utils/browser.py
@@ -1,7 +1,13 @@
 import asyncio
+import os
 from typing import List
 from playwright.async_api import async_playwright, BrowserContext, Page
 from utils.user_agent import get_random_ua
+
+# External CDP endpoint (e.g. BrowserUse cloud session, browserless, plain
+# chromium --remote-debugging-port). When set, the app connects to that
+# browser instead of launching a local bundled Chromium.
+CDP_URL = os.environ.get("BROWSER_CDP_URL", "").strip() or None
 
 
 class PlaywrightManager:
@@ -11,7 +17,10 @@ class PlaywrightManager:
 
     async def start(self):
         self._playwright = await async_playwright().start()
-        self._browser = await self._playwright.chromium.launch(headless=True)
+        if CDP_URL:
+            self._browser = await self._playwright.chromium.connect_over_cdp(CDP_URL)
+        else:
+            self._browser = await self._playwright.chromium.launch(headless=True)
 
     async def new_context_page(self):
         context = await self._browser.new_context(user_agent=get_random_ua())
@@ -46,14 +55,18 @@ class OptimizedPlaywrightManager:
     async def start(self):
         """Initialize the browser and create initial context pool"""
         self._playwright = await async_playwright().start()
-        self._browser = await self._playwright.chromium.launch(headless=True)
+        if CDP_URL:
+            self._browser = await self._playwright.chromium.connect_over_cdp(CDP_URL)
+        else:
+            self._browser = await self._playwright.chromium.launch(headless=True)
 
         # Pre-create some contexts for the pool
         initial_contexts = min(3, self._max_contexts)
-        for _ in range(initial_contexts):
-            context = await self._browser.new_context(user_agent=get_random_ua())
-            self._context_pool.append(context)
-            self._contexts_created += 1
+        if not CDP_URL:  # skip pre-warm against external/ephemeral browsers
+            for _ in range(initial_contexts):
+                context = await self._browser.new_context(user_agent=get_random_ua())
+                self._context_pool.append(context)
+                self._contexts_created += 1
 
     async def get_context(self) -> BrowserContext:
         """Get a browser context from the pool or create a new one"""


### PR DESCRIPTION
## What

Allow the API to attach to an **external Chromium-compatible browser** over the Chrome DevTools Protocol instead of launching a bundled local Chromium.

Set `BROWSER_CDP_URL` to a `ws(s)://` or `http://` CDP endpoint — a BrowserUse cloud session, browserless, a plain `chromium --remote-debugging-port=9222`, etc. — and `connect_over_cdp()` is used in both `PlaywrightManager` and `OptimizedPlaywrightManager`. Unset (default) behavior is **unchanged**.

```bash
BROWSER_CDP_URL=wss://<session>.cdp.browser-use.com/devtools/browser/<id> uvicorn main:app --port 8000
```

## Why

Run the API in RAM-constrained environments (containers, small VPS, Fly.io `shared-1x-256mb`). With the browser external, the API process idles at **~100 MB RSS** versus **~0.5–1 GB** with a resident headless Chromium, and inherits the external browser's fingerprint/stealth characteristics — useful for targets with bot protection.

## Implementation notes

- Context-pool **pre-warm is skipped** when `BROWSER_CDP_URL` is set: external browsers are often ephemeral or billed per session, so pre-creating 3 pooled contexts at startup is wasteful or fails outright. Contexts are created on demand (the pool still reuses them per request).
- Everything else (per-context user agents, `clear_cookies()` on release, semaphore concurrency) works unchanged over CDP.

## Verification

End-to-end against a BrowserUse cloud session: app startup connects in ~1.2 s, live searches return full result sets, `ps` confirms **no local Chromium process** during operation. Also exercised uvloop + the optimized manager path under `uvicorn main:app` (i.e. the real `lifespan` startup, not just a script).

Independent of the selector fix — based directly on `main` (850bd42), so it can be merged in either order.